### PR TITLE
feat: drop bluefin-dx add latest

### DIFF
--- a/.github/actions/get-images/action.yml
+++ b/.github/actions/get-images/action.yml
@@ -26,7 +26,7 @@ runs:
           ;;
         "Desktop")
           images+=("bluefin" "bluefin-nvidia")
-          images+=("bluefin-dx" "bluefin-dx-nvidia")
+          images+=("bluefin-latest" "bluefin-latest-nvidia")
           ;;
         "Server")
           images+=("ucore-minimal" "ucore" "ucore-nvidia")

--- a/Justfile
+++ b/Justfile
@@ -9,8 +9,8 @@ images := '(
     [bazzite-deck]="bazzite-deck-gnome"
     [bluefin]="bluefin"
     [bluefin-nvidia]="bluefin-nvidia"
-    [bluefin-dx]="bluefin-dx"
-    [bluefin-dx-nvidia]="bluefin-dx-nvidia"
+    [bluefin-latest]="bluefin"
+    [bluefin-latest-nvidia]="bluefin-nvidia"
     [cosmic]="cosmic"
     [cosmic-nvidia]="cosmic-nvidia"
     [ucore-minimal]="stable"
@@ -73,17 +73,41 @@ build image="bluefin":
         exit 1
     fi
     BUILD_ARGS=()
+
     case "{{ image }}" in
+    "aurora-latest"*|"bluefin-latest"*)
+        BASE_IMAGE="${check}"
+        TAG_VERSION=latest
+        ;;
     "aurora"*|"bluefin"*)
         BASE_IMAGE="${check}"
         TAG_VERSION=stable-daily
+        ;;
+    "bazzite"*)
+        BASE_IMAGE="${check}"
+        TAG_VERSION=stable
+        ;;
+    "ucore-minimal"*)
+        BASE_IMAGE=ucore-minimal
+        TAG_VERSION="${check}"
+        ;;
+    "ucore-hci"*)
+        BASE_IMAGE=ucore-hci
+        TAG_VERSION="${check}"
+        ;;
+    "ucore"*)
+        BASE_IMAGE=ucore
+        TAG_VERSION="${check}"
+        ;;
+    esac
+
+    case "{{ image }}" in
+    "aurora"*|"bluefin"*)
         just verify-container "${BASE_IMAGE}":"${TAG_VERSION}"
         skopeo inspect docker://ghcr.io/ublue-os/"${BASE_IMAGE}":"${TAG_VERSION}" > /tmp/inspect-"{{ image }}".json
         fedora_version="$(jq -r '.Labels["ostree.linux"]' < /tmp/inspect-{{ image }}.json | grep -oP 'fc\K[0-9]+')"
         ;;
     "bazzite"*)
-        BASE_IMAGE="${check}"
-        TAG_VERSION=stable
         just verify-container "${BASE_IMAGE}":"${TAG_VERSION}"
         skopeo inspect docker://ghcr.io/ublue-os/"${BASE_IMAGE}":"${TAG_VERSION}" > /tmp/inspect-"{{ image }}".json
         fedora_version="$(jq -r '.Labels["ostree.linux"]' < /tmp/inspect-{{ image }}.json | grep -oP 'fc\K[0-9]+')"
@@ -97,27 +121,9 @@ build image="bluefin":
         just verify-container "${BASE_IMAGE}":"${TAG_VERSION}"
         skopeo inspect docker://ghcr.io/ublue-os/coreos-stable-kernel:"${fedora_version}" > /tmp/inspect-"{{ image }}".json
         ;;
-    "ucore-minimal"*)
-        BASE_IMAGE=ucore-minimal
-        TAG_VERSION="${check}"
-        just verify-container "${BASE_IMAGE}":"${TAG_VERSION}"
-        fedora_version="$(skopeo inspect docker://ghcr.io/ublue-os/"${BASE_IMAGE}":"${check}" | jq -r '.Labels["ostree.linux"]' | grep -oP 'fc\K[0-9]+')"
-        just verify-container coreos-stable-kernel:"${fedora_version}"
-        skopeo inspect docker://ghcr.io/ublue-os/coreos-stable-kernel:"${fedora_version}" > /tmp/inspect-"{{ image }}".json
-        ;;
-    "ucore-hci"*)
-        BASE_IMAGE=ucore-hci
-        TAG_VERSION="${check}"
-        just verify-container "${BASE_IMAGE}":"${TAG_VERSION}"
-        fedora_version="$(skopeo inspect docker://ghcr.io/ublue-os/"${BASE_IMAGE}":"${check}" | jq -r '.Labels["ostree.linux"]' | grep -oP 'fc\K[0-9]+')"
-        just verify-container coreos-stable-kernel:"${fedora_version}"
-        skopeo inspect docker://ghcr.io/ublue-os/coreos-stable-kernel:"${fedora_version}" > /tmp/inspect-"{{ image }}".json
-        ;;
     "ucore"*)
-        BASE_IMAGE=ucore
-        TAG_VERSION="${check}"
         just verify-container "${BASE_IMAGE}":"${TAG_VERSION}"
-        fedora_version="$(skopeo inspect docker://ghcr.io/ublue-os/"${BASE_IMAGE}":"${check}" | jq -r '.Labels["ostree.linux"]' | grep -oP 'fc\K[0-9]+')"
+        fedora_version="$(skopeo inspect docker://ghcr.io/ublue-os/"${BASE_IMAGE}":"${TAG_VERSION}" | jq -r '.Labels["ostree.linux"]' | grep -oP 'fc\K[0-9]+')"
         just verify-container coreos-stable-kernel:"${fedora_version}"
         skopeo inspect docker://ghcr.io/ublue-os/coreos-stable-kernel:"${fedora_version}" > /tmp/inspect-"{{ image }}".json
         ;;

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Desktop(and laptop) images are built upon [Bluefin](https://github.com/ublue-os/
 
 - `bos:bluefin` - a Bluefin stable-daily image with ZFS support
 - `bos:bluefin-nvidia` - a Bluefin stable-daily image with ZFS and Nvidia support
-- `bos:bluefin-dx` - a Bluefin stable-daily image with ZFS support and extra developer features
-- `bos:bluefin-dx-nvidia` - a Bluefin stable-daily image with ZFS and Nvidia support and extra developer features
+- `bos:bluefin-latest` - a Bluefin stable-daily image with ZFS support and extra developer features
+- `bos:bluefin-latest-nvidia` - a Bluefin stable-daily image with ZFS and Nvidia support and extra developer features
 
 ### Servers
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Desktop(and laptop) images are built upon [Bluefin](https://github.com/ublue-os/
 
 - `bos:bluefin` - a Bluefin stable-daily image with ZFS support
 - `bos:bluefin-nvidia` - a Bluefin stable-daily image with ZFS and Nvidia support
-- `bos:bluefin-latest` - a Bluefin stable-daily image with ZFS support and extra developer features
-- `bos:bluefin-latest-nvidia` - a Bluefin stable-daily image with ZFS and Nvidia support and extra developer features
+- `bos:bluefin-latest` - a Bluefin latest image
+- `bos:bluefin-latest-nvidia` - a Bluefin latest image with Nvidia support
 
 ### Servers
 

--- a/desktop-packages.sh
+++ b/desktop-packages.sh
@@ -48,6 +48,7 @@ dnf5 install --setopt=install_weak_deps=False -y \
     libvirt-nss \
     lm_sensors \
     ltrace \
+    nerd-fonts \
     patch \
     pipx \
     podman-machine \

--- a/desktop-packages.sh
+++ b/desktop-packages.sh
@@ -23,6 +23,15 @@ dnf5 install --setopt=install_weak_deps=False -y \
     adw-gtk3-theme \
     cascadia-code-fonts \
     ccache \
+    cockpit-bridge \
+    cockpit-files \
+    cockpit-machines \
+    cockpit-networkmanager \
+    cockpit-ostree \
+    cockpit-podman \
+    cockpit-selinux \
+    cockpit-storaged \
+    cockpit-system \
     code \
     devpod \
     edk2-ovmf \
@@ -34,6 +43,8 @@ dnf5 install --setopt=install_weak_deps=False -y \
     libpcap-devel \
     libretls \
     libvirt \
+    libvirt-daemon-kvm \
+    libvirt-ssh-proxy \
     libvirt-nss \
     lm_sensors \
     ltrace \
@@ -58,6 +69,9 @@ dnf5 install --setopt=install_weak_deps=False -y \
     shellcheck \
     shfmt \
     strace \
+    udisks2-btrfs \
+    udisks2-lvm2 \
+    virt-install \
     virt-manager \
     virt-viewer \
     virt-v2v \

--- a/desktop-packages.sh
+++ b/desktop-packages.sh
@@ -9,28 +9,62 @@ echo "Running desktop packages scripts..."
 dnf5 -y copr enable ublue-os/staging
 dnf5 -y copr enable bsherman1/rkvm
 
+# VSCode because it's still better for a lot of things
+tee /etc/yum.repos.d/vscode.repo <<'EOF'
+[code]
+name=Visual Studio Code
+baseurl=https://packages.microsoft.com/yumrepos/vscode
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+EOF
+
 # common packages installed to desktops
-dnf5 install -y \
+dnf5 install --setopt=install_weak_deps=False -y \
+    adw-gtk3-theme \
+    cascadia-code-fonts \
+    ccache \
+    code \
+    devpod \
+    edk2-ovmf \
+    genisoimage \
     gh \
     ghostty \
     gnome-shell-extension-no-overview \
-    ibm-plex-fonts-all \
+    ibm-plex-mono-fonts \
     libpcap-devel \
     libretls \
+    libvirt \
+    libvirt-nss \
+    lm_sensors \
     ltrace \
     patch \
     pipx \
+    podman-machine \
+    powerline-fonts \
+    qemu-char-spice \
+    qemu-device-display-virtio-gpu \
+    qemu-device-display-virtio-vga \
+    qemu-device-usb-redirect \
+    qemu-img \
+    qemu-kvm \
+    qemu-system-x86-core \
+    qemu-user-binfmt \
+    qemu-user-static \
+    qemu \
     rkvm \
+    rocm-hip \
+    rocm-opencl \
+    rocm-smi \
     rsms-inter-fonts \
     shellcheck \
     shfmt \
     strace \
-    udica \
+    virt-manager \
+    virt-viewer \
+    virt-v2v \
     yamllint \
     ydotool
-
-dnf5 -y copr disable ublue-os/staging
-dnf5 -y copr disable bsherman1/rkvm
 
 # github direct installs
 /ctx/github-release-install.sh twpayne/chezmoi x86_64

--- a/server-changes.sh
+++ b/server-changes.sh
@@ -2,9 +2,12 @@
 
 set ${SET_X:+-x} -eou pipefail
 
-echo "Tweaking existing server config..."
-
 if [[ ${IMAGE} =~ ucore ]]; then
+    echo "Tweaking existing server config..."
+
+    # cockpit extensions not in ucore
+    dnf5 install -y cockpit-files cockpit-ostree
+
     # moby-engine packages on uCore conflict with docker-ce
     dnf5 remove -y \
         containerd moby-engine runc

--- a/server-packages.sh
+++ b/server-packages.sh
@@ -8,8 +8,15 @@ echo "Running server packages scripts..."
 # common packages installed to desktops and servers
 dnf5 install -y \
     bc \
+    cockpit-bridge \
     cockpit-files \
+    cockpit-machines \
+    cockpit-networkmanager \
     cockpit-ostree \
+    cockpit-podman \
+    cockpit-selinux \
+    cockpit-storaged \
+    cockpit-system \
     erofs-utils \
     hdparm \
     intel_gpu_top \
@@ -17,13 +24,16 @@ dnf5 install -y \
     ipcalc \
     iperf3 \
     just \
-    lm_sensors \
     lshw \
     lzip \
     netcat \
+    nicstat \
     nmap \
+    numactl \
+    podman-tui \
     p7zip \
     p7zip-plugins \
     picocom \
     socat \
+    udica \
     unrar

--- a/server-packages.sh
+++ b/server-packages.sh
@@ -8,15 +8,6 @@ echo "Running server packages scripts..."
 # common packages installed to desktops and servers
 dnf5 install -y \
     bc \
-    cockpit-bridge \
-    cockpit-files \
-    cockpit-machines \
-    cockpit-networkmanager \
-    cockpit-ostree \
-    cockpit-podman \
-    cockpit-selinux \
-    cockpit-storaged \
-    cockpit-system \
     erofs-utils \
     hdparm \
     intel_gpu_top \


### PR DESCRIPTION
This change drops our `-dx` specific bluefin builds, instead adding some of the packages from -dx to all our desktop builds (and some to ucore).

In addition, add a bluefin `-latest` variety so I can test latest kernels.