### PR TITLE
feat: add bazzite kde; scope gnome-only changes to gnome variants

### DIFF
--- a/.github/actions/get-images/action.yml
+++ b/.github/actions/get-images/action.yml
@@ -23,6 +23,7 @@ runs:
         case "${{ inputs.image_flavor }}" in
         "Bazzite")
           images+=("bazzite" "bazzite-nvidia")
+          images+=("bazzite-gnome" "bazzite-gnome-nvidia")
           #images+=("bazzite-deck" "bazzite-deck-nvidia")
           ;;
         "Bluefin")

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -62,7 +62,8 @@ jobs:
 
       - name: Free Disk Space (Ubuntu)
         if: ${{ steps.check_mnt.outputs.mnt_is_there == '1' }}
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        # v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
       - name: Mount BTRFS for podman storage
         uses: ublue-os/container-storage-action@main
@@ -98,7 +99,7 @@ jobs:
           echo "tags=$tags" >> $GITHUB_OUTPUT
           echo $GITHUB_OUTPUT
       # NOTE: disabled secureboot check since bluefin LTS will never pass
-      #- name: Check Secureboot
+      # - name: Check Secureboot
       #  id: secureboot
       #  shell: bash
       #  run: |
@@ -150,8 +151,9 @@ jobs:
           contains(fromJson('["workflow_dispatch", "merge_group"]'),
           github.event_name) || github.event.schedule == '41 6 * * 0'
         run: |
+          REGISTRY="${{ steps.registry_case.outputs.lowercase }}"
           cosign sign -y --key env://COSIGN_PRIVATE_KEY \
-              ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
+              "${REGISTRY}/${{ env.IMAGE_NAME }}@${TAGS}"
         env:
           TAGS: >-
             ${{ steps.push.outputs.outputs

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cosign.key
+CLAUDE.md

--- a/Justfile
+++ b/Justfile
@@ -5,10 +5,12 @@ username := "bsherman"
 images := '(
     [aurora]="aurora"
     [aurora-nvidia]="aurora-nvidia"
-    [bazzite]="bazzite-gnome"
-    [bazzite-nvidia]="bazzite-gnome-nvidia"
-    [bazzite-deck]="bazzite-deck-gnome"
-    [bazzite-deck-nvidia]="bazzite-deck-nvidia-gnome"
+    [bazzite]="bazzite"
+    [bazzite-nvidia]="bazzite-nvidia"
+    [bazzite-deck]="bazzite-deck"
+    [bazzite-deck-nvidia]="bazzite-deck-nvidia"
+    [bazzite-gnome]="bazzite-gnome"
+    [bazzite-gnome-nvidia]="bazzite-gnome-nvidia"
     [bluefin-latest]="bluefin-dx"
     [bluefin-latest-nvidia]="bluefin-dx-nvidia-open"
     [bluefin-gdx]="bluefin-gdx"
@@ -346,8 +348,11 @@ build-iso image="bluefin" ghcr="0" clean="0":
     *"aurora"*)
         FLATPAK_LIST_URL="https://raw.githubusercontent.com/ublue-os/aurora/refs/heads/main/aurora_flatpaks/flatpaks"
     ;;
-    *"bazzite"*)
+    *"bazzite-gnome"*)
         FLATPAK_LIST_URL="https://raw.githubusercontent.com/ublue-os/bazzite/refs/heads/main/installer/gnome_flatpaks/flatpaks"
+    ;;
+    *"bazzite"*)
+        FLATPAK_LIST_URL="https://raw.githubusercontent.com/ublue-os/bazzite/refs/heads/main/installer/kde_flatpaks/flatpaks"
     ;;
     *"bluefin"*)
         FLATPAK_LIST_URL="https://raw.githubusercontent.com/ublue-os/bluefin/refs/heads/main/bluefin_flatpaks/flatpaks"
@@ -361,7 +366,7 @@ build-iso image="bluefin" ghcr="0" clean="0":
         app/org.libreoffice.LibreOffice/x86_64/stable
         app/org.prismlauncher.PrismLauncher/x86_64/stable
     )
-    if [[ "{{ image }}" =~ bazzite ]]; then
+    if [[ "{{ image }}" =~ bazzite-gnome ]]; then
         ADDITIONAL_FLATPAKS+=(app/org.gnome.World.PikaBackup/x86_64/stable)
     elif [[ "{{ image }}" =~ aurora|bluefin ]]; then
         ADDITIONAL_FLATPAKS+=(app/it.mijorus.gearlever/x86_64/stable)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,15 @@ There's a single image name `bos` with multiple tags. The idea is, *I run **bOS*
 
 Desktop(and laptop) images are built upon [Bazzite](https://github.com/ublue-os/bazzite).
 
-- `bos:bazzite` - a Bazzite
-- `bos:bazzite-nvidia` - a Bazzite image with Nvidia support
+**KDE variants** (default Bazzite desktop):
+
+- `bos:bazzite` - a Bazzite (KDE)
+- `bos:bazzite-nvidia` - a Bazzite image with Nvidia support (KDE)
+
+**GNOME variants**:
+
+- `bos:bazzite-gnome` - a Bazzite (GNOME)
+- `bos:bazzite-gnome-nvidia` - a Bazzite image with Nvidia support (GNOME)
 
 ### Servers
 

--- a/branding.sh
+++ b/branding.sh
@@ -24,6 +24,7 @@ case "${IMAGE}" in
     base_image="kinoite"
     ;;
 "ucore"*)
+    # shellcheck disable=SC2153
     base_image="${BASE_IMAGE}"
     ;;
 esac

--- a/desktop-changes.sh
+++ b/desktop-changes.sh
@@ -12,18 +12,21 @@ if [[ ${IMAGE} =~ bluefin|bazzite ]]; then
         ln -s /var/opt /opt
     fi
     if [[ ! -h /usr/local ]]; then
+        # shellcheck disable=SC2114
         rm -fr /usr/local
         ln -s /var/usrlocal /usr/local
     fi
-
-    # copy system files
-    rsync -rvK /ctx/system_files/silverblue/ /
 
     # remove solaar and input leap, if installed
     $DNF -y remove input-leap solaar virt-manager virt-viewer virt-v2v
 
     # ensure no moby-engine packages, we can use sysext if needed
     $DNF remove -y containerd docker-buildx docker-cli docker-compose moby-engine runc
+fi
+
+if [[ ${IMAGE} =~ bluefin|bazzite-gnome ]]; then
+    # copy system files
+    rsync -rvK /ctx/system_files/silverblue/ /
 
     # custom gnome overrides
     mkdir -p /tmp/ublue-schema-test &&

--- a/desktop-packages.sh
+++ b/desktop-packages.sh
@@ -22,6 +22,10 @@ EOF
 # common packages installed to desktops
 $DNF install --setopt=install_weak_deps=False -y \
     code \
-    gnome-shell-extension-no-overview \
     jetbrains-mono-fonts-all \
     powerline-fonts
+
+if [[ ${IMAGE} =~ bazzite-gnome|bluefin|aurora ]]; then
+    $DNF install --setopt=install_weak_deps=False -y \
+        gnome-shell-extension-no-overview
+fi

--- a/server-packages.sh
+++ b/server-packages.sh
@@ -32,7 +32,7 @@ $DNF install -y \
     unzip \
     zip
 
-/ctx/github-release-install.sh frostyard/updex $(uname -m).rpm
+/ctx/github-release-install.sh frostyard/updex "$(uname -m).rpm"
 
 if [[ ${IMAGE} =~ ucore-hci ]]; then
     $DNF install -y incus


### PR DESCRIPTION
## Summary

- Add `bazzite` and `bazzite-nvidia` as KDE variants alongside existing `bazzite-gnome`/`bazzite-gnome-nvidia`
- Scope system files rsync and gnome-shell extension install to gnome variants only
- Fix cosign sign command to use a variable for the registry value
- Fix shellcheck issues in `branding.sh` and `server-packages.sh`