### PR TITLE
feat: add aarch64 support for ucore and ucore-minimal builds

### DIFF
--- a/.github/actions/get-images/action.yml
+++ b/.github/actions/get-images/action.yml
@@ -7,8 +7,11 @@ inputs:
     required: true
 outputs:
   images:
-    description: "List of Images that will be built"
+    description: "List of image/arch/runner combos to build"
     value: ${{ steps.images.outputs.images }}
+  multi_arch_images:
+    description: "List of image names that need manifest creation"
+    value: ${{ steps.images.outputs.multi_arch_images }}
 runs:
   using: "composite"
   steps:
@@ -16,30 +19,53 @@ runs:
       id: images
       shell: bash
       run: |-
-        # Array to Hold Image Names
-        images=()
+        # Images that should build for both x86_64 and aarch64
+        multi_arch=()
+        # Images that only build for x86_64
+        single_arch=()
 
-        # Add Images
         case "${{ inputs.image_flavor }}" in
         "Bazzite")
-          images+=("bazzite" "bazzite-nvidia")
-          images+=("bazzite-gnome" "bazzite-gnome-nvidia")
-          #images+=("bazzite-deck" "bazzite-deck-nvidia")
+          single_arch+=("bazzite" "bazzite-nvidia")
+          single_arch+=("bazzite-gnome" "bazzite-gnome-nvidia")
+          #single_arch+=("bazzite-deck" "bazzite-deck-nvidia")
           ;;
         "Bluefin")
-          images+=("bluefin" "bluefin-nvidia")
+          single_arch+=("bluefin" "bluefin-nvidia")
           ;;
         "Server")
-          images+=("ucore-minimal" "ucore" "ucore-nvidia")
-          images+=("ucore-hci" "ucore-hci-nvidia")
-          images+=("ucore-minimal-lts" "ucore-lts" "ucore-lts-nvidia")
-          images+=("ucore-hci-lts" "ucore-hci-lts-nvidia")
+          multi_arch+=("ucore-minimal" "ucore")
+          multi_arch+=("ucore-minimal-lts" "ucore-lts")
+          single_arch+=("ucore-nvidia" "ucore-hci" "ucore-hci-nvidia")
+          single_arch+=("ucore-lts-nvidia")
+          single_arch+=("ucore-hci-lts" "ucore-hci-lts-nvidia")
           ;;
         esac
 
-        # Make into Json Array
-        images="$(jq --null-input --compact-output '$ARGS.positional' \
-        --args "${images[@]}")"
+        # Build structured JSON array
+        combos="[]"
+        for img in "${single_arch[@]}"; do
+          combos=$(echo "$combos" | jq -c \
+            --arg image "$img" \
+            '. + [{
+              "image": $image,
+              "arch": "x86_64",
+              "runner": "ubuntu-24.04"
+            }]')
+        done
+        for img in "${multi_arch[@]}"; do
+          combos=$(echo "$combos" | jq -c \
+            --arg image "$img" \
+            '. + [
+              {"image": $image, "arch": "x86_64", "runner": "ubuntu-24.04"},
+              {"image": $image, "arch": "aarch64", "runner": "ubuntu-24.04-arm"}
+            ]')
+        done
+
+        # Multi-arch image names list
+        multi_arch_json="$(jq --null-input --compact-output \
+          '$ARGS.positional' --args "${multi_arch[@]}")"
 
         # Output
-        echo "images=$images" >> "$GITHUB_OUTPUT"
+        echo "images=$combos" >> "$GITHUB_OUTPUT"
+        echo "multi_arch_images=$multi_arch_json" >> "$GITHUB_OUTPUT"

--- a/.github/actions/install-just/action.yml
+++ b/.github/actions/install-just/action.yml
@@ -15,11 +15,15 @@ runs:
                 https://api.github.com/repos/casey/just/releases/latest |
             jq -r '.tag_name')
         done
+        ARCH=$(uname -m)
+        case "${ARCH}" in
+          aarch64) TARGET="aarch64-unknown-linux-musl" ;;
+          *)       TARGET="x86_64-unknown-linux-musl" ;;
+        esac
         URL="https://github.com/casey/just/releases/download"
-        TARGZ="just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+        TARGZ="just-${JUST_VERSION}-${TARGET}.tar.gz"
         curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSLO \
           ${URL}/${JUST_VERSION}/${TARGZ}
-        tar -zxvf just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-          -C /tmp just
+        tar -zxvf ${TARGZ} -C /tmp just
         sudo mv /tmp/just /usr/local/bin/just
-        rm -f just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
+        rm -f ${TARGZ}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -19,6 +19,7 @@ jobs:
     name: Get ${{ inputs.image_flavor }} Images for Build
     outputs:
       images: ${{ steps.images.outputs.images }}
+      multi_arch_images: ${{ steps.images.outputs.multi_arch_images }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,9 +30,11 @@ jobs:
         with:
           image_flavor: ${{ inputs.image_flavor }}
   build-image:
-    name: Build ${{ inputs.image_flavor }} Images (${{ matrix.image }})
+    name: >-
+      Build ${{ inputs.image_flavor }} Images
+      (${{ matrix.combo.image }}/${{ matrix.combo.arch }})
     needs: get-images
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.combo.runner }}
     continue-on-error: false
     permissions:
       contents: read
@@ -40,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["${{ fromJson(needs.get-images.outputs.images) }}"]
+        combo: ${{ fromJson(needs.get-images.outputs.images) }}
     steps:
       - name: Checkout
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493  # v4
@@ -78,32 +81,54 @@ jobs:
         shell: bash
         run: |
           # note: if disabling rechunker, must also disable sudo call
-          # just build ${{ matrix.image }}
-          sudo just build ${{ matrix.image }}
+          # just build ${{ matrix.combo.image }}
+          sudo just build ${{ matrix.combo.image }}
 
       - name: Rechunk Image
         shell: bash
         run: |
-          sudo just rechunk ${{ matrix.image }}
+          sudo just rechunk ${{ matrix.combo.image }}
 
       - name: Load and Tag Image
         shell: bash
         run: |
-          just load-image ${{ matrix.image }}
+          just load-image ${{ matrix.combo.image }}
 
       - name: Get Tags
         id: get_tags
         shell: bash
         run: |
-          tags=$(just get-tags ${{ matrix.image }})
+          tags=$(just get-tags ${{ matrix.combo.image }})
           echo "tags=$tags" >> $GITHUB_OUTPUT
           echo $GITHUB_OUTPUT
+
+      - name: Compute Push Tags
+        id: push_tags
+        shell: bash
+        run: |
+          TAGS="${{ steps.get_tags.outputs.tags }}"
+          MULTI_ARCH='${{ needs.get-images.outputs.multi_arch_images }}'
+          IMAGE="${{ matrix.combo.image }}"
+          ARCH="${{ matrix.combo.arch }}"
+          IS_MULTI=$(echo "$MULTI_ARCH" | \
+            jq -r --arg img "$IMAGE" 'any(.[]; . == $img)')
+          if [[ "$IS_MULTI" == "true" ]]; then
+            # Append -<arch> to each tag
+            SUFFIXED=""
+            for tag in $TAGS; do
+              SUFFIXED+="${tag}-${ARCH} "
+            done
+            TAGS="${SUFFIXED% }"
+          fi
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          echo "is_multi_arch=$IS_MULTI" >> $GITHUB_OUTPUT
+
       # NOTE: disabled secureboot check since bluefin LTS will never pass
       # - name: Check Secureboot
       #  id: secureboot
       #  shell: bash
       #  run: |
-      #    just secureboot ${{ matrix.image }}
+      #    just secureboot ${{ matrix.combo.image }}
       - name: Lowercase Registry
         id: registry_case
         uses: ASzc/change-string-case-action@v6
@@ -124,7 +149,7 @@ jobs:
           attempt_delay: 15000
           with: |
             image: ${{ env.IMAGE_NAME }}
-            tags: ${{ steps.get_tags.outputs.tags }}
+            tags: ${{ steps.push_tags.outputs.tags }}
             registry: ${{ steps.registry_case.outputs.lowercase }}
             username: ${{ env.REGISTRY_USER }}
             password: ${{ env.REGISTRY_PASSWORD }}
@@ -133,8 +158,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         if: >-
-          contains(fromJson('["workflow_dispatch", "merge_group"]'),
-          github.event_name) || github.event.schedule == '41 6 * * 0'
+          (contains(fromJson('["workflow_dispatch", "merge_group"]'),
+          github.event_name) || github.event.schedule == '41 6 * * 0')
+          && steps.push_tags.outputs.is_multi_arch != 'true'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -144,12 +170,14 @@ jobs:
         with:
           cosign-release: 'v2.6.1'
         if: >-
-          contains(fromJson('["workflow_dispatch", "merge_group"]'),
-          github.event_name) || github.event.schedule == '41 6 * * 0'
+          (contains(fromJson('["workflow_dispatch", "merge_group"]'),
+          github.event_name) || github.event.schedule == '41 6 * * 0')
+          && steps.push_tags.outputs.is_multi_arch != 'true'
       - name: Sign Container Image
         if: >-
-          contains(fromJson('["workflow_dispatch", "merge_group"]'),
-          github.event_name) || github.event.schedule == '41 6 * * 0'
+          (contains(fromJson('["workflow_dispatch", "merge_group"]'),
+          github.event_name) || github.event.schedule == '41 6 * * 0')
+          && steps.push_tags.outputs.is_multi_arch != 'true'
         run: |
           REGISTRY="${{ steps.registry_case.outputs.lowercase }}"
           cosign sign -y --key env://COSIGN_PRIVATE_KEY \
@@ -159,16 +187,104 @@ jobs:
             ${{ steps.push.outputs.outputs
             && fromJSON(steps.push.outputs.outputs).digest }}
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+  create-manifest:
+    name: Create Manifest (${{ matrix.image }})
+    needs: [get-images, build-image]
+    if: >-
+      (contains(fromJson('["workflow_dispatch", "merge_group"]'),
+      github.event_name) || github.event.schedule == '41 6 * * 0')
+      && needs.get-images.outputs.multi_arch_images != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.get-images.outputs.multi_arch_images) }}
+    steps:
+      - name: Lowercase Registry
+        id: registry_case
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ env.IMAGE_REGISTRY }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Version Tag
+        id: version
+        run: |
+          REGISTRY="${{ steps.registry_case.outputs.lowercase }}"
+          # Inspect x86_64 image to get the version tag
+          IMG="${REGISTRY}/${{ env.IMAGE_NAME }}"
+          VERSION=$(skopeo inspect \
+            --creds \
+            "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+            "docker://${IMG}:${{ matrix.image }}-x86_64" \
+            | jq -r \
+            '.Labels["org.opencontainers.image.version"]')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Create and Push Manifests
+        run: |
+          REGISTRY="${{ steps.registry_case.outputs.lowercase }}"
+          IMAGE="${REGISTRY}/${{ env.IMAGE_NAME }}"
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Create manifest for image name tag
+          docker manifest create \
+            "${IMAGE}:${{ matrix.image }}" \
+            "${IMAGE}:${{ matrix.image }}-x86_64" \
+            "${IMAGE}:${{ matrix.image }}-aarch64"
+          docker manifest push "${IMAGE}:${{ matrix.image }}"
+
+          # Create manifest for version tag
+          docker manifest create \
+            "${IMAGE}:${VERSION}" \
+            "${IMAGE}:${VERSION}-x86_64" \
+            "${IMAGE}:${VERSION}-aarch64"
+          docker manifest push "${IMAGE}:${VERSION}"
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+        with:
+          cosign-release: 'v2.6.1'
+      - name: Sign Manifests
+        run: |
+          REGISTRY="${{ steps.registry_case.outputs.lowercase }}"
+          IMAGE="${REGISTRY}/${{ env.IMAGE_NAME }}"
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Sign image name manifest
+          DIGEST=$(skopeo inspect --raw \
+            --creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+            "docker://${IMAGE}:${{ matrix.image }}" \
+            | sha256sum | awk '{print "sha256:"$1}')
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY \
+            "${IMAGE}@${DIGEST}"
+
+          # Sign version manifest
+          DIGEST=$(skopeo inspect --raw \
+            --creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+            "docker://${IMAGE}:${VERSION}" \
+            | sha256sum | awk '{print "sha256:"$1}')
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY \
+            "${IMAGE}@${DIGEST}"
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
   check:
     name: Check Build ${{ inputs.image_flavor }} Images Successful
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    needs: [build-image]
+    needs: [build-image, create-manifest]
     steps:
       - name: Exit on failure
         if: >-
           ${{ contains(fromJson('["failure", "skipped"]'),
-          needs.build-image.result) }}
+          needs.build-image.result)
+          || needs.create-manifest.result == 'failure' }}
         shell: bash
         run: exit 1
       - name: Exit

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -274,7 +274,8 @@ jobs:
             --creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
             "docker://${IMAGE}:${{ matrix.image }}" \
             | sha256sum | awk '{print "sha256:"$1}')
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY \
+          cosign sign -y --recursive \
+            --key env://COSIGN_PRIVATE_KEY \
             "${IMAGE}@${DIGEST}"
 
           # Sign version manifest
@@ -282,7 +283,8 @@ jobs:
             --creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
             "docker://${IMAGE}:${VERSION}" \
             | sha256sum | awk '{print "sha256:"$1}')
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY \
+          cosign sign -y --recursive \
+            --key env://COSIGN_PRIVATE_KEY \
             "${IMAGE}@${DIGEST}"
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -123,6 +123,18 @@ jobs:
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
           echo "is_multi_arch=$IS_MULTI" >> $GITHUB_OUTPUT
 
+      - name: Tag Images for Multi-Arch Push
+        if: steps.push_tags.outputs.is_multi_arch == 'true'
+        shell: bash
+        run: |
+          ORIG_TAGS="${{ steps.get_tags.outputs.tags }}"
+          ARCH="${{ matrix.combo.arch }}"
+          for tag in $ORIG_TAGS; do
+            podman tag \
+              ${{ env.IMAGE_NAME }}:${tag} \
+              ${{ env.IMAGE_NAME }}:${tag}-${ARCH}
+          done
+
       # NOTE: disabled secureboot check since bluefin LTS will never pass
       # - name: Check Secureboot
       #  id: secureboot

--- a/Justfile
+++ b/Justfile
@@ -132,9 +132,9 @@ build image="bluefin":
 
     VERSION="{{ image }}-${fedora_version}.$(date +%Y%m%d)"
     skopeo list-tags docker://ghcr.io/{{ repo_name }}/{{ repo_image_name }} > /tmp/repotags.json
-    if [[ $(jq "any(.Tags[]; contains(\"$VERSION\"))" < /tmp/repotags.json) == "true" ]]; then
+    if [[ $(jq "any(.Tags[]; . == \"$VERSION\" or startswith(\"${VERSION}-\"))" < /tmp/repotags.json) == "true" ]]; then
         POINT="1"
-        while jq -e "any(.Tags[]; contains(\"$VERSION.$POINT\"))" < /tmp/repotags.json
+        while jq -e "any(.Tags[]; . == \"$VERSION.$POINT\" or startswith(\"${VERSION}.${POINT}-\"))" < /tmp/repotags.json
         do
             (( POINT++ ))
         done


### PR DESCRIPTION
## Summary
- Add aarch64 builds for `ucore`, `ucore-minimal`, `ucore-lts`, and `ucore-minimal-lts`
- Multi-arch manifest lists combine x86_64 and aarch64 variants under the same tag
- Fix `install-just` action to detect architecture dynamically
- Fix Justfile version tag matching to use exact match (avoids false positives with arch-suffixed tags)

## Test plan
- [x] Verify all matrix entries (both arches) build successfully on PR
- [x] Trigger `workflow_dispatch` to test full push + manifest flow
- [x] `skopeo inspect --raw docker://ghcr.io/bsherman/bos:ucore-minimal` shows manifest list with amd64 + arm64
- [x] `cosign verify --key cosign.pub ghcr.io/bsherman/bos:ucore-minimal` succeeds
- [x] Confirm desktop/bazzite builds are unaffected (x86_64 only, no manifest step)