### PR TITLE
fix: authenticate GitHub API calls to avoid rate limit failures

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Build Image
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           # note: if disabling rechunker, must also disable sudo call
           # just build ${{ matrix.combo.image }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           # note: if disabling rechunker, must also disable sudo call
           # just build ${{ matrix.combo.image }}
-          sudo env PATH="$PATH" just build ${{ matrix.combo.image }}
+          sudo env PATH="$PATH" GITHUB_TOKEN="$GITHUB_TOKEN" just build ${{ matrix.combo.image }}
 
       - name: Rechunk Image
         shell: bash

--- a/Containerfile
+++ b/Containerfile
@@ -14,4 +14,5 @@ ARG VERSION=""
 ARG DNF=""
 
 RUN --mount=type=bind,from=ctx,src=/,dst=/ctx \
+    --mount=type=secret,id=GITHUB_TOKEN \
     /ctx/build.sh

--- a/Justfile
+++ b/Justfile
@@ -164,6 +164,9 @@ build image="bluefin":
     echo "::endgroup::"
 
     echo "::group:: Container Build"
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        BUILD_ARGS+=("--secret" "id=GITHUB_TOKEN,env=GITHUB_TOKEN")
+    fi
     {{ PODMAN }} build "${BUILD_ARGS[@]}" .
     echo "::endgroup::"
 

--- a/github-release-install.sh
+++ b/github-release-install.sh
@@ -44,8 +44,15 @@ set ${SET_X:+-x} -eou pipefail
 API_JSON=$(mktemp /tmp/api-XXXXXXXX.json)
 API="https://api.github.com/repos/${ORG_PROJ}/releases/${RELTAG}"
 
+# Read GitHub token from secret mount if available (authenticates API to avoid rate limits)
+CURL_AUTH_ARGS=()
+if [[ -r /run/secrets/GITHUB_TOKEN ]]; then
+    GITHUB_TOKEN=$(</run/secrets/GITHUB_TOKEN)
+    CURL_AUTH_ARGS=("-H" "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
 # retry up to 5 times with 5 second delays for any error included HTTP 404 etc
-curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sL "${API}" -o "${API_JSON}"
+curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sL \
+    "${CURL_AUTH_ARGS[@]}" "${API}" -o "${API_JSON}"
 RPM_URLS=$(jq \
     -r \
     --arg arch_filter "${ARCH_FILTER}" \

--- a/github-release-url.sh
+++ b/github-release-url.sh
@@ -44,8 +44,15 @@ set ${SET_X:+-x} -eou pipefail
 API_JSON=$(mktemp /tmp/api-XXXXXXXX.json)
 API="https://api.github.com/repos/${ORG_PROJ}/releases/${RELTAG}"
 
+# Read GitHub token from secret mount if available (authenticates API to avoid rate limits)
+CURL_AUTH_ARGS=()
+if [[ -r /run/secrets/GITHUB_TOKEN ]]; then
+    GITHUB_TOKEN=$(</run/secrets/GITHUB_TOKEN)
+    CURL_AUTH_ARGS=("-H" "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
 # retry up to 5 times with 5 second delays for any error included HTTP 404 etc
-curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sL "${API}" -o "${API_JSON}"
+curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sL \
+    "${CURL_AUTH_ARGS[@]}" "${API}" -o "${API_JSON}"
 TGZ_URLS=$(jq \
     -r \
     --arg arch_filter "${ARCH_FILTER}" \


### PR DESCRIPTION
## Problem

CI builds intermittently fail when `github-release-install.sh` (and `github-release-url.sh`) call the GitHub API unauthenticated to fetch the latest release for `frostyard/updex`. Shared GitHub Actions runner IPs hit the 60 req/hour unauthenticated limit, causing `curl --fail` to exit non-zero and fail the build.

## Solution

Pass `github.token` (5,000 req/hour) as a build secret so the API calls are authenticated. Graceful degradation is preserved: if `GITHUB_TOKEN` is absent (local builds), the secret mount is skipped and curl runs unauthenticated as before.

## Changes

- **`github-release-install.sh`** / **`github-release-url.sh`** — read `/run/secrets/GITHUB_TOKEN` if present and pass `-H "Authorization: Bearer …"` to curl
- **`Containerfile`** — add `--mount=type=secret,id=GITHUB_TOKEN` to the `RUN` instruction (`required` defaults to `false`, so absent secret is a no-op)
- **`Justfile`** — conditionally append `--secret id=GITHUB_TOKEN,env=GITHUB_TOKEN` to `BUILD_ARGS` when `GITHUB_TOKEN` is set in the environment
- **`.github/workflows/build-image.yml`** — expose `GITHUB_TOKEN: ${{ github.token }}` on the Build Image step so `sudo env PATH="$PATH"` forwards it to `just`