### PR TITLE
ci: build only changed upstream images

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -2,8 +2,7 @@
 name: bOS Build Desktop
 on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: "41 6 * * 5"  # 6:41 UTC Friday
-    - cron: "41 6 * * 0,1,2,3,4,6"  # 6:41 UTC Sunday-Thursday, Saturday
+    - cron: "41 6 * * *"  # 6:41 UTC daily
   push:
     branches:
       - main
@@ -47,4 +46,3 @@ jobs:
         image_flavor: ["Bazzite"]
     with:
       image_flavor: ${{ matrix.image_flavor }}
-      publish_schedule: '41 6 * * 5'

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -251,7 +251,7 @@ jobs:
       (contains(fromJson('["workflow_dispatch", "merge_group"]'),
       github.event_name) || github.event.schedule == inputs.publish_schedule)
       && needs.get-images.outputs.manifest_images != '[]'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,14 +5,12 @@ on:  # yamllint disable-line rule:truthy
     inputs:
       image_flavor:
         type: string
-      publish_schedule:
-        type: string
-        default: '41 6 * * 0'
 concurrency:
   group: >-
     ${{ github.workflow }}-${{ github.ref
     || github.run_id }}-${{ inputs.image_flavor }}
-  cancel-in-progress: true
+  # Do not interrupt a publishing run after it has pushed only some arches.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 env:
   IMAGE_REGISTRY: ghcr.io/bsherman
   IMAGE_NAME: bos
@@ -23,17 +21,51 @@ jobs:
     outputs:
       images: ${{ steps.images.outputs.images }}
       manifest_images: ${{ steps.images.outputs.manifest_images }}
-    runs-on: ubuntu-latest
+      publish: ${{ steps.images.outputs.publish }}
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3
+      - name: Install Skopeo
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes skopeo
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+        with:
+          cosign-release: 'v3.1.2'
+      - name: Login to GHCR
+        shell: bash
+        run: |
+          echo "${{ github.token }}" | skopeo login ghcr.io \
+            --username "${{ github.actor }}" --password-stdin
       - name: Get Images for Build
         id: images
         shell: bash
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          images=$(just generate-ci-matrix "${{ inputs.image_flavor }}")
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            changed_only=true
+          else
+            changed_only=false
+          fi
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            publish=false
+          else
+            publish=true
+          fi
+
+          images=$(just generate-ci-matrix \
+            "${{ inputs.image_flavor }}" "${changed_only}")
           manifest_images=$(jq -c '
             reduce .[] as $e ({}; .[$e.image] = (.[$e.image] // []) + [$e.arch])
             | to_entries
@@ -41,6 +73,7 @@ jobs:
           ' <<<"$images")
           echo "images=$images" >> "$GITHUB_OUTPUT"
           echo "manifest_images=$manifest_images" >> "$GITHUB_OUTPUT"
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
   build-image:
     name: >-
       Build ${{ inputs.image_flavor }} Images
@@ -119,13 +152,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          # just build ${{ matrix.combo.image }}
+          # Pin the build to the upstream digest selected by get-images.
           sudo env \
             XDG_RUNTIME_DIR=/tmp \
             TMPDIR="${TMPDIR:-/tmp}" \
             PATH="$PATH" \
             GITHUB_TOKEN="$GITHUB_TOKEN" \
-            just build ${{ matrix.combo.image }}
+            just build ${{ matrix.combo.image }} \
+              ${{ matrix.combo.base_digest }}
 
       - name: Show disk space (after build)
         if: ${{ always() && steps.build.conclusion != 'skipped' }}
@@ -165,6 +199,16 @@ jobs:
         shell: bash
         run: |
           just load-chunked-oci ${{ matrix.combo.image }}
+
+      - name: Verify upstream base metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="${{ matrix.combo.image }}"
+          local_image="localhost/${{ env.IMAGE_NAME }}:${image}"
+          base_digest=$(podman inspect "${local_image}" | jq -r \
+            '.[0].Config.Labels["org.opencontainers.image.base.digest"]')
+          test "$base_digest" = "${{ matrix.combo.base_digest }}"
 
       - name: Show disk space (after load)
         if: ${{ always() && steps.load.conclusion != 'skipped' }}
@@ -220,9 +264,7 @@ jobs:
           string: ${{ env.IMAGE_REGISTRY }}
       - name: Push to GHCR
         id: push
-        if: >-
-          contains(fromJson('["workflow_dispatch", "merge_group"]'),
-          github.event_name) || github.event.schedule == inputs.publish_schedule
+        if: ${{ needs.get-images.outputs.publish == 'true' }}
         env:
           REGISTRY_USER: ${{ github.actor }}
           REGISTRY_PASSWORD: ${{ github.token }}
@@ -235,9 +277,7 @@ jobs:
       - name: Push Chunked Image to GHCR
         uses: ./.github/actions/push-image
         id: push_chunked
-        if: >-
-          contains(fromJson('["workflow_dispatch", "merge_group"]'),
-          github.event_name) || github.event.schedule == inputs.publish_schedule
+        if: ${{ needs.get-images.outputs.publish == 'true' }}
         with:
           image-ref: ${{ env.IMAGE_NAME }}:${{ matrix.combo.image }}
           image-name: ${{ env.IMAGE_NAME }}
@@ -248,8 +288,7 @@ jobs:
     name: Create Manifest (${{ matrix.entry.image }})
     needs: [get-images, build-image]
     if: >-
-      (contains(fromJson('["workflow_dispatch", "merge_group"]'),
-      github.event_name) || github.event.schedule == inputs.publish_schedule)
+      needs.get-images.outputs.publish == 'true'
       && needs.get-images.outputs.manifest_images != '[]'
     runs-on: ubuntu-26.04
     permissions:
@@ -382,13 +421,15 @@ jobs:
     name: Check Build ${{ inputs.image_flavor }} Images Successful
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    needs: [build-image, create-manifest]
+    needs: [get-images, build-image, create-manifest]
     steps:
       - name: Exit on failure
         if: >-
-          ${{ contains(fromJson('["failure", "skipped"]'),
+          needs.get-images.result == 'failure'
+          || (needs.get-images.outputs.images != '[]'
+          && (contains(fromJson('["failure", "skipped"]'),
           needs.build-image.result)
-          || needs.create-manifest.result == 'failure' }}
+          || needs.create-manifest.result == 'failure'))
         shell: bash
         run: exit 1
       - name: Exit

--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -2,8 +2,7 @@
 name: bOS Build Server
 on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: "41 6 * * 5"  # 6:41 UTC Friday
-    - cron: "41 6 * * 0,1,2,3,4,6"  # 6:41 UTC Sunday-Thursday, Saturday
+    - cron: "41 6 * * *"  # 6:41 UTC daily
   push:
     branches:
       - main
@@ -47,4 +46,3 @@ jobs:
         image_flavor: ["Server"]
     with:
       image_flavor: ${{ matrix.image_flavor }}
-      publish_schedule: '41 6 * * 5'

--- a/Containerfile
+++ b/Containerfile
@@ -1,11 +1,10 @@
-ARG BASE_IMAGE="bluefin"
-ARG BASE_TAG="stable-daily@sha256:2d7b7ea13d91092f6bdb7b710b2baba649c2c577c668e3df1635ed6e52a18a03"
+ARG BASE_REF="ucore-minimal:stable"
 ARG IMAGE="bluefin"
 
 FROM scratch AS ctx
 COPY / /
 
-FROM ghcr.io/ublue-os/${BASE_IMAGE}:${BASE_TAG}
+FROM ghcr.io/ublue-os/${BASE_REF}
 
 ARG BASE_IMAGE="bluefin"
 ARG DNF=""

--- a/Justfile
+++ b/Justfile
@@ -31,32 +31,190 @@ list-images flavor="":
     fi
 
 # Generate the matrix JSON expected by GitHub Actions for a given flavor.
-# Example: just generate-ci-matrix Server
+# With changed_only=true, include only variants whose signed published image
+# does not record the current upstream manifest digest.
+# Example: just generate-ci-matrix Server true
 [group('CI')]
-generate-ci-matrix flavor:
+generate-ci-matrix flavor changed_only="false":
     #!/usr/bin/env bash
-    set -euo pipefail
+    set ${SET_X:+-x} -eou pipefail
+
+    if [[ "{{ changed_only }}" != "true" && "{{ changed_only }}" != "false" ]]; then
+        echo "changed_only must be true or false" >&2
+        exit 1
+    fi
+
+    upstream_registry="${UPSTREAM_REGISTRY:-ghcr.io/ublue-os}"
+    image_registry="${IMAGE_REGISTRY:-ghcr.io/bsherman}"
+    image_name="${IMAGE_NAME:-bos}"
+    cosign_key="${COSIGN_PUBLIC_KEY:-cosign.pub}"
+    tmpdir="$(mktemp -d -t bos-ci-matrix.XXXXXXXXXX)"
+    trap 'rm -rf "${tmpdir}"' EXIT
+
+    declare -A upstream_digests=()
+    resolved_digest=""
+
+    retry() {
+        local attempt
+        for attempt in 1 2 3; do
+            if "$@"; then
+                return 0
+            fi
+            if [[ "${attempt}" == "3" ]]; then
+                return 1
+            fi
+            sleep "$((5 * attempt))"
+        done
+    }
+
+    upstream_digest() {
+        local base_image="$1"
+        local base_tag="$2"
+        local key="${base_image}:${base_tag}"
+        local manifest_hash
+        local manifest
+        local attempt
+
+        manifest_hash="$(sha256sum <<<"${key}" | cut -d ' ' -f 1)"
+        manifest="${tmpdir}/${manifest_hash}"
+
+        if [[ -n "${upstream_digests[${key}]:-}" ]]; then
+            resolved_digest="${upstream_digests[${key}]}"
+            return
+        fi
+
+        for attempt in 1 2 3; do
+            : > "${manifest}"
+            if skopeo inspect --raw \
+                "docker://${upstream_registry}/${key}" > "${manifest}"
+            then
+                break
+            fi
+            if [[ "${attempt}" == "3" ]]; then
+                echo "Unable to inspect upstream image ${upstream_registry}/${key}" >&2
+                return 1
+            fi
+            sleep "$((5 * attempt))"
+        done
+
+        if [[ ! -s "${manifest}" ]]; then
+            echo "Unable to inspect upstream image ${upstream_registry}/${key}" >&2
+            return 1
+        fi
+
+        upstream_digests["${key}"]="sha256:$(sha256sum "${manifest}" | cut -d ' ' -f 1)"
+        resolved_digest="${upstream_digests[${key}]}"
+    }
+
+    variant_needs_rebuild() {
+        local image="$1"
+        local multi_arch="$2"
+        local base_digest="$3"
+        local arch oci_arch label inspect_error label_file attempt inspected
+        local -a arches=(x86_64)
+
+        if [[ "${multi_arch}" == "true" ]]; then
+            arches+=(aarch64)
+        fi
+
+        for arch in "${arches[@]}"; do
+            case "${arch}" in
+            x86_64)
+                oci_arch=amd64
+                ;;
+            aarch64)
+                oci_arch=arm64
+                ;;
+            esac
+
+            inspect_error="${tmpdir}/${image}-${arch}.inspect-error"
+            label_file="${tmpdir}/${image}-${arch}.label"
+            inspected=false
+            for attempt in 1 2 3; do
+                : > "${label_file}"
+                : > "${inspect_error}"
+                if skopeo inspect --override-arch "${oci_arch}" \
+                    --format '{{ '{{ index .Labels "org.opencontainers.image.base.digest" }}' }}' \
+                    "docker://${image_registry}/${image_name}:${image}" \
+                    > "${label_file}" 2>"${inspect_error}"
+                then
+                    label="$(< "${label_file}")"
+                    inspected=true
+                    break
+                fi
+                if [[ "${attempt}" != "3" ]]; then
+                    sleep "$((5 * attempt))"
+                fi
+            done
+
+            if [[ "${inspected}" != "true" ]]; then
+                if grep -qiE \
+                    'manifest unknown|name unknown|not found|no image found|status code: 404' \
+                    "${inspect_error}"
+                then
+                    # A missing published image is expected for new variants.
+                    return 0
+                fi
+                echo "Unable to inspect published image ${image}" >&2
+                cat "${inspect_error}" >&2
+                return 2
+            fi
+
+            if [[ "${label}" != "${base_digest}" ]]; then
+                return 0
+            fi
+        done
+
+        if ! retry cosign verify --new-bundle-format=false \
+            --key "${cosign_key}" \
+            "${image_registry}/${image_name}:${image}" >/dev/null
+        then
+            return 0
+        fi
+
+        return 1
+    }
 
     entries=$({{ YQ }} -r '
-        .flavors["{{ flavor }}"][] 
-        | select((.ci_enabled // false) == true) 
-        | .tag + " " + ((.multi_arch // false) | tostring)
+        .flavors["{{ flavor }}"][]
+        | select((.ci_enabled // false) == true)
+        | [.tag, .base_image, (.base_tag // "stable"),
+           ((.multi_arch // false) | tostring)]
+        | @tsv
     ' images.yaml)
 
     result="[]"
-    while read -r tag multi; do
+    while IFS=$'\t' read -r tag base_image base_tag multi; do
         [[ -z "$tag" ]] && continue
+        upstream_digest "${base_image}" "${base_tag}"
+        base_digest="${resolved_digest}"
+
+        if [[ "{{ changed_only }}" == "true" ]]; then
+            if variant_needs_rebuild "${tag}" "${multi}" "${base_digest}"; then
+                :
+            else
+                status=$?
+                if [[ "${status}" == "1" ]]; then
+                    echo "Skipping ${tag}; ${base_image}:${base_tag} is unchanged" >&2
+                    continue
+                fi
+                exit "${status}"
+            fi
+        fi
+
         if [[ "$multi" == "true" ]]; then
             result=$(echo "$result" | jq -c \
                 --arg img "$tag" \
+                --arg base_digest "${base_digest}" \
                 '. + [
-                    {image: $img, arch: "x86_64", runner: "ubuntu-26.04"},
-                    {image: $img, arch: "aarch64", runner: "ubuntu-26.04-arm"}
+                    {image: $img, arch: "x86_64", runner: "ubuntu-26.04", base_digest: $base_digest},
+                    {image: $img, arch: "aarch64", runner: "ubuntu-26.04-arm", base_digest: $base_digest}
                 ]')
         else
             result=$(echo "$result" | jq -c \
                 --arg img "$tag" \
-                '. + [{image: $img, arch: "x86_64", runner: "ubuntu-26.04"}]')
+                --arg base_digest "${base_digest}" \
+                '. + [{image: $img, arch: "x86_64", runner: "ubuntu-26.04", base_digest: $base_digest}]')
         fi
     done <<< "$entries"
 
@@ -97,7 +255,7 @@ clean:
 
 # Build Image
 [group('Image')]
-build image="bluefin":
+build image="bluefin" base_digest="":
     #!/usr/bin/env bash
     echo "::group:: Container Build Prep"
     set ${SET_X:+-x} -eou pipefail
@@ -111,11 +269,22 @@ build image="bluefin":
 
     # Read build metadata from images.yaml (single source of truth)
     BASE_TAG=$({{ YQ }} -r '.flavors[][] | select(.tag == "{{ image }}") | .base_tag // "stable"' images.yaml)
-    DIST_ABRV=$({{ YQ }} -r '.flavors[][] | select(.tag == "{{ image }}") | .dist_abrv // "fc"' images.yaml)
     DNF=$({{ YQ }} -r '.flavors[][] | select(.tag == "{{ image }}") | .dnf // "dnf5"' images.yaml)
 
     # Note: For the ucore family, base_image and base_tag are read directly from images.yaml.
     # No extra swapping is needed after the rename.
+
+    BASE_REF="${BASE_IMAGE}:${BASE_TAG}"
+    if [[ -n "{{ base_digest }}" ]]; then
+        if [[ ! "{{ base_digest }}" =~ ^sha256:[[:xdigit:]]{64}$ ]]; then
+            echo "Error: Invalid base digest '{{ base_digest }}'." >&2
+            exit 1
+        fi
+        BASE_DIGEST="{{ base_digest }}"
+    else
+        BASE_DIGEST="sha256:$(skopeo inspect --raw "docker://ghcr.io/ublue-os/${BASE_REF}" | sha256sum | cut -d ' ' -f 1)"
+    fi
+    BASE_REF+="@${BASE_DIGEST}"
 
     BUILD_ARGS=()
     TMPFILES=()
@@ -126,14 +295,14 @@ build image="bluefin":
 
     case "{{ image }}" in
     "ucore"*)
-        just verify-container "${BASE_IMAGE}":"${BASE_TAG}"
-        fedora_version="$(skopeo inspect docker://ghcr.io/ublue-os/"${BASE_IMAGE}":"${BASE_TAG}" | jq -r '.Labels["org.opencontainers.image.version"]' | grep -oP '^(?:[[:alpha:]]+-)?\K[0-9]+')"
+        just verify-container "${BASE_REF}"
+        fedora_version="$(skopeo inspect "docker://ghcr.io/ublue-os/${BASE_REF}" | jq -r '.Labels["org.opencontainers.image.version"]' | grep -oP '^(?:[[:alpha:]]+-)?\K[0-9]+')"
         ;;
     *)
-        just verify-container "${BASE_IMAGE}":"${BASE_TAG}"
+        just verify-container "${BASE_REF}"
         inspect_json="$(mktemp -t inspect-{{ image }}.XXXXXXXXXX.json)"
         TMPFILES+=("${inspect_json}")
-        skopeo inspect docker://ghcr.io/ublue-os/"${BASE_IMAGE}":"${BASE_TAG}" > "${inspect_json}"
+        skopeo inspect "docker://ghcr.io/ublue-os/${BASE_REF}" > "${inspect_json}"
         fedora_version="$(jq -r '.Labels["org.opencontainers.image.version"]' < "${inspect_json}" | grep -oP '^(?:[[:alpha:]]+-)?\K[0-9]+')"
         ;;
     esac
@@ -156,9 +325,11 @@ build image="bluefin":
     BUILD_ARGS+=("--label" "org.opencontainers.image.title={{ repo_image_name_styled }}")
     BUILD_ARGS+=("--label" "org.opencontainers.image.version=$VERSION")
     BUILD_ARGS+=("--label" "org.opencontainers.image.description={{ repo_image_name }} is my OCI image built from ublue projects. It mainly extends them for my uses.")
+    BUILD_ARGS+=("--label" "org.opencontainers.image.base.name=ghcr.io/ublue-os/${BASE_IMAGE}:${BASE_TAG}")
+    BUILD_ARGS+=("--label" "org.opencontainers.image.base.digest=${BASE_DIGEST}")
     BUILD_ARGS+=("--build-arg" "IMAGE={{ image }}")
     BUILD_ARGS+=("--build-arg" "BASE_IMAGE=$BASE_IMAGE")
-    BUILD_ARGS+=("--build-arg" "BASE_TAG=$BASE_TAG")
+    BUILD_ARGS+=("--build-arg" "BASE_TAG=${BASE_TAG}@${BASE_DIGEST}")
     BUILD_ARGS+=("--build-arg" "SET_X=${SET_X:-}")
     BUILD_ARGS+=("--build-arg" "VERSION=$VERSION")
     BUILD_ARGS+=("--build-arg" "DNF=$DNF")
@@ -185,7 +356,7 @@ build image="bluefin":
     {{ PODMAN }} images
     echo "::endgroup::"
 
-    {{ PODMAN }} rmi ghcr.io/ublue-os/"${BASE_IMAGE}":"${BASE_TAG}"
+    {{ PODMAN }} rmi "ghcr.io/ublue-os/${BASE_REF}" || true
 
 # Chunk Image
 [group('Image')]
@@ -278,8 +449,9 @@ build-iso image="bluefin" ghcr="0" clean="0":
     just verify-container "build-container-installer" "ghcr.io/jasonn3" "https://raw.githubusercontent.com/JasonN3/build-container-installer/refs/heads/main/cosign.pub"
 
     mkdir -p {{ repo_image_name }}_build/{lorax_templates,flatpak-refs-{{ image }},output}
-    echo 'append etc/anaconda/profile.d/fedora-kinoite.conf "\\n[User Interface]\\nhidden_spokes =\\n    PasswordSpoke"' \
-         > {{ repo_image_name }}_build/lorax_templates/remove_root_password_prompt.tmpl
+    printf '%s\n' \
+        'append etc/anaconda/profile.d/fedora-kinoite.conf "\\n[User Interface]\\nhidden_spokes =\\n    PasswordSpoke"' \
+        > {{ repo_image_name }}_build/lorax_templates/remove_root_password_prompt.tmpl
 
     # Build from GHCR or localhost
     if [[ "{{ ghcr }}" == "1" ]]; then
@@ -369,7 +541,7 @@ build-iso image="bluefin" ghcr="0" clean="0":
     -v "${TEMP_FLATPAK_INSTALL_DIR}":/temp_flatpak_install_dir \
     "${IMAGE_FULL}" /temp_flatpak_install_dir/install-flatpaks.sh
 
-    VERSION="$({{ SUDOIF }} {{ PODMAN }} inspect ${IMAGE_FULL} | jq -r '.[]["Config"]["Labels"]["org.opencontainers.image.version"]' | grep -oP '\K[0-9]+'')"
+    VERSION="$({{ SUDOIF }} {{ PODMAN }} inspect ${IMAGE_FULL} | jq -r '.[]["Config"]["Labels"]["org.opencontainers.image.version"]' | grep -oP '\K[0-9]+')"
     if [[ "{{ ghcr }}" == "1" && "{{ clean }}" == "1" ]]; then
         {{ SUDOIF }} {{ PODMAN }} rmi ${IMAGE_FULL}
     fi
@@ -568,3 +740,4 @@ lint-recipes:
     for recipe in build chunk build-iso run-iso; do
         just _lint-recipe "shellcheck -e SC2050,SC2194" "${recipe}" bluefin
     done
+    just _lint-recipe "shellcheck -e SC2050,SC2194" generate-ci-matrix Bazzite false

--- a/Justfile
+++ b/Justfile
@@ -274,7 +274,7 @@ build image="bluefin" base_digest="":
     # Note: For the ucore family, base_image and base_tag are read directly from images.yaml.
     # No extra swapping is needed after the rename.
 
-    BASE_REF="${BASE_IMAGE}:${BASE_TAG}"
+    BASE_TAG_REF="${BASE_IMAGE}:${BASE_TAG}"
     if [[ -n "{{ base_digest }}" ]]; then
         if [[ ! "{{ base_digest }}" =~ ^sha256:[[:xdigit:]]{64}$ ]]; then
             echo "Error: Invalid base digest '{{ base_digest }}'." >&2
@@ -282,9 +282,9 @@ build image="bluefin" base_digest="":
         fi
         BASE_DIGEST="{{ base_digest }}"
     else
-        BASE_DIGEST="sha256:$(skopeo inspect --raw "docker://ghcr.io/ublue-os/${BASE_REF}" | sha256sum | cut -d ' ' -f 1)"
+        BASE_DIGEST="sha256:$(skopeo inspect --raw "docker://ghcr.io/ublue-os/${BASE_TAG_REF}" | sha256sum | cut -d ' ' -f 1)"
     fi
-    BASE_REF+="@${BASE_DIGEST}"
+    BASE_REF="${BASE_IMAGE}@${BASE_DIGEST}"
 
     BUILD_ARGS=()
     TMPFILES=()
@@ -329,7 +329,7 @@ build image="bluefin" base_digest="":
     BUILD_ARGS+=("--label" "org.opencontainers.image.base.digest=${BASE_DIGEST}")
     BUILD_ARGS+=("--build-arg" "IMAGE={{ image }}")
     BUILD_ARGS+=("--build-arg" "BASE_IMAGE=$BASE_IMAGE")
-    BUILD_ARGS+=("--build-arg" "BASE_TAG=${BASE_TAG}@${BASE_DIGEST}")
+    BUILD_ARGS+=("--build-arg" "BASE_REF=$BASE_REF")
     BUILD_ARGS+=("--build-arg" "SET_X=${SET_X:-}")
     BUILD_ARGS+=("--build-arg" "VERSION=$VERSION")
     BUILD_ARGS+=("--build-arg" "DNF=$DNF")

--- a/Justfile
+++ b/Justfile
@@ -50,13 +50,13 @@ generate-ci-matrix flavor:
             result=$(echo "$result" | jq -c \
                 --arg img "$tag" \
                 '. + [
-                    {image: $img, arch: "x86_64", runner: "ubuntu-24.04"},
-                    {image: $img, arch: "aarch64", runner: "ubuntu-24.04-arm"}
+                    {image: $img, arch: "x86_64", runner: "ubuntu-26.04"},
+                    {image: $img, arch: "aarch64", runner: "ubuntu-26.04-arm"}
                 ]')
         else
             result=$(echo "$result" | jq -c \
                 --arg img "$tag" \
-                '. + [{image: $img, arch: "x86_64", runner: "ubuntu-24.04"}]')
+                '. + [{image: $img, arch: "x86_64", runner: "ubuntu-26.04"}]')
         fi
     done <<< "$entries"
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ upstream image changed are rebuilt and published. Pull requests always build
 enabled variants for validation but do not publish; merges to `main` publish
 all enabled variants.
 
+Workflows run daily. The first scheduled run after adding digest metadata
+rebuilds every enabled variant because existing published images lack it.
+
 ## DIY
 
 This repo was built on the [Universal Blue Image Template](https://github.com/ublue-os/image-template) though it's been added to significantly.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ These images are signed with sigstore's [cosign](https://docs.sigstore.dev/cosig
 cosign verify --key cosign.pub ghcr.io/bsherman/bos:TAG
 ```
 
+## Build Scheduling
+
+Scheduled builds compare each variant's exact upstream image digest with the
+digest recorded on its signed published image. Only scheduled variants whose
+upstream image changed are rebuilt and published. Pull requests always build
+enabled variants for validation but do not publish; merges to `main` publish
+all enabled variants.
+
 ## DIY
 
 This repo was built on the [Universal Blue Image Template](https://github.com/ublue-os/image-template) though it's been added to significantly.

--- a/images.yaml
+++ b/images.yaml
@@ -7,18 +7,24 @@
 #   - ci_enabled: true   (fedora-desktop + ucore bases)
 #   - multi_arch: true   (ucore base only)
 #
-# Booleans default as above. Only override when you want different behavior
-# (e.g. Bluefin sets ci_enabled: false; single-arch ucore variants set multi_arch: false).
+# Booleans default as above. Only override when you want different behavior.
+# For example, Bluefin sets ci_enabled: false and single-arch ucore variants
+# set multi_arch: false.
 #
 # Field Key:
-#   tag          : Name used with `just build <tag>` and for the final published image tags.
-#   base_image   : Upstream image name under ghcr.io/ublue-os/ (the part before the colon in FROM/inspect).
+#   tag          : Name used with `just build <tag>` and for published tags.
+#   base_image   : Upstream image name under ghcr.io/ublue-os/.
+#                  It is the part before the colon in FROM/inspect.
 #   base_tag     : Tag to use on the upstream base image.
-#   multi_arch   : Build this variant for both x86_64 and aarch64? Defaults to false.
-#   ci_enabled   : Include this variant in GitHub Actions CI builds? Defaults to false.
-#   dist_abrv    : Distribution abbreviation used in the build ("fc" for Fedora, "el" for Enterprise Linux).
+#   multi_arch   : Build this variant for both x86_64 and aarch64?
+#                  Defaults to false.
+#   ci_enabled   : Include this variant in GitHub Actions CI builds?
+#                  Defaults to false.
+#   dist_abrv    : Distribution abbreviation used in the build.
+#                  "fc" is Fedora and "el" is Enterprise Linux.
 #   dnf          : Package manager to use during the build ("dnf5" or "dnf").
 
+---
 templates:
   fedora-desktop: &fedora-desktop
     dist_abrv: fc


### PR DESCRIPTION
## Summary
- move Podman, Skopeo, and Buildah workflow jobs to Ubuntu 26.04 runners
- rebuild scheduled variants only when their exact signed upstream base digest changes
- pin image builds to the resolved upstream digest and record it in OCI labels
- publish scheduled updates immediately, retain PR validation-only behavior, and make no-change matrices succeed
- enable CI matrix tracing and fix YAML and recipe lint violations

## Validation
- `just lint`
- `just generate-ci-matrix Bazzite false`
- `just generate-ci-matrix Server false`
- digest-pinned upstream Cosign verification
- `git diff --check`