### PR TITLE
fix(ci): assemble manifests from stable arch tags

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -376,7 +376,7 @@ jobs:
           IMAGE_DIGEST="$(cat "${DIGESTFILE}")"
 
           podman manifest create "${IMAGE}:${VERSION}"
-          add_arches "${IMAGE}:${VERSION}" "${VERSION}"
+          add_arches "${IMAGE}:${VERSION}" "${IMAGE_TAG}"
           podman manifest push \
             --all=false \
             --digestfile "${DIGESTFILE}" \


### PR DESCRIPTION
## Summary
- assemble version manifests from the stable per-architecture tags
- avoid assuming concurrent architecture builds select the same point version

## Validation
- `just lint`
- YAML lint
- local Podman manifest assembly from real `ucore-minimal-lts` x86_64 and aarch64 tags
- `git diff --check`