### PR TITLE
chore: ignore fallback base digest pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,14 @@
       ]
     },
     {
+      "description": "Keep the Containerfile fallback base tag unpinned",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": ["Containerfile"],
+      "matchPackageNames": ["ghcr.io/ublue-os/ucore-minimal"],
+      "matchUpdateTypes": ["pinDigest"],
+      "enabled": false
+    },
+    {
       "description": "Group all GitHub Actions",
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions"


### PR DESCRIPTION
## Summary
- ignore Renovate pinDigest updates for the Containerfile `ucore-minimal:stable` fallback
- retain Renovate updates for every other UBlue image and CI source

## Validation
- `jq empty .github/renovate.json`
- `renovate-config-validator .github/renovate.json`
- `just lint`
- `git diff --check`