### PR TITLE
chore: adopt agentic-template structure for agent-maintained docs

### DIFF
--- a/.agents/skills/TEMPLATE/SKILL.md.txt
+++ b/.agents/skills/TEMPLATE/SKILL.md.txt
@@ -1,0 +1,27 @@
+---
+name: skill-name
+description: One sentence saying what this skill produces and one sentence saying when to use it ("Use whenever asked to …"). Agents pick skills by this description alone — make the trigger unmistakable.
+---
+
+# Imperative title (e.g. "Build a new widget")
+
+<!--
+A skill is a repeatable procedure an agent should follow instead of
+improvising. Copy this directory, rename it, and register the skill with a
+bullet in AGENTS.md's Skills section. Keep steps concrete: name the commands,
+files, and checks. Link the design docs/specs that govern the steps rather
+than restating them.
+-->
+
+State the goal in one line, and what "done" looks like.
+
+## Steps
+
+1. First step — the command to run or file to edit, and what to verify.
+2. Next step.
+3. Verify: the project check to run and the observable outcome that proves
+   the procedure worked.
+
+## Pitfalls
+
+- Known failure mode an agent hits on this path, and the correction.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+---
+name: Lint
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+jobs:
+  lint:
+    name: Shell, YAML, and Justfile Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Just
+        uses: >-
+          extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3
+
+      - name: Install Linters
+        shell: bash
+        run: |
+          # shellcheck is preinstalled on GitHub-hosted Ubuntu runners.
+          shellcheck --version
+          pipx install yamllint
+
+      - name: Lint
+        shell: bash
+        run: just lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+.claude/settings.local.json
 cosign.key
-AGENTS.md
-CLAUDE.md
 bos_*.oci
 bos_*.config.json
 version.txt
+changelog*.md
+output*.env
+previous.manifest.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,127 @@
+# bOS
+
+Personal Universal Blue-derived OCI image builds, published as a single image
+name `bos` with multiple tags (Bazzite desktop variants, uCore server
+variants). Start at [docs/README.md](docs/README.md) for the full docs index.
+
+This file (`AGENTS.md`) is the CANONICAL agent instructions — `CLAUDE.md`,
+`GEMINI.md`, and `.github/copilot-instructions.md` are symlinks to it, and
+`.claude/skills` symlinks to `.agents/skills/`
+([ADR-0002](docs/adr/0002-agent-portable-instruction-surface.md)). Edit only
+the canonical paths; keep content tool-agnostic.
+
+## Skills (follow these for common tasks)
+
+Step-by-step procedures live in [.agents/skills/](.agents/skills/); follow
+them rather than improvising, whichever agent you are:
+
+- *(none yet — add the first one when a procedure repeats)*
+
+Start a new skill by copying `.agents/skills/TEMPLATE/SKILL.md.txt` to
+`.agents/skills/<name>/SKILL.md` (the template keeps a `.txt` extension so it
+is not itself discovered as a skill), then register it with a bullet above.
+
+## Project structure & module organization
+
+The root contains the primary build surface: `Containerfile`, `Justfile`,
+`build.sh`, and `images.yaml` (the single source of truth for all image
+variants, their upstream bases, multi-arch status, CI enablement, and build
+metadata such as `base_tag`). Build scripts live in `build_scripts/` (e.g.
+`desktop-packages.sh`, `server-packages.sh`, `shared-changes.sh`, etc.).
+Configuration overlays live in `system_files/`, grouped by image family, for
+example `system_files/shared/` and `system_files/sysext/`. GitHub Actions
+workflows are in `.github/workflows/`, with reusable local actions in
+`.github/actions/`. There is no application source tree or conventional test
+directory; validation is driven by linting, recipe checks, and image builds.
+
+## Build, test, and development commands
+
+Use `just --list` to see available recipes. Common commands:
+
+- `just build bazzite` builds a local `localhost/bos:bazzite` image.
+- `just build ucore` builds a server image variant.
+- `just generate-ci-matrix Server true` shows changed server variants selected
+  for a scheduled CI build.
+- `just lint` runs shell, YAML, Justfile, and generated recipe lint checks.
+- `just format` applies `shfmt`, `yamlfmt`, and Justfile formatting.
+- `just check` verifies Justfile syntax without rewriting files.
+- `just clean` removes generated image/changelog artifacts from local builds.
+
+Local builds require Podman or Docker plus tools used by the recipes,
+including `just`, `skopeo`, `jq`, `cosign`, `shellcheck`, `shfmt`, `yamllint`,
+and `yamlfmt`.
+
+## Code conventions (live — the code exists)
+
+- Shell scripts use Bash with `set -eou pipefail` where practical.
+- Follow `.editorconfig`: four-space indentation for `*.sh`, LF line endings,
+  final newlines, trimmed trailing whitespace, and an 80-column target. Keep
+  scripts executable when they are meant to run directly.
+- Prefer descriptive variant names matching image tags, such as
+  `bazzite-gnome-nvidia` or `ucore-hci-lts`.
+- `images.yaml` is the single source of truth for image variants — add or
+  change a variant there, not by hardcoding tags in scripts or workflows.
+- Run `just lint` (shell, YAML, Justfile, and generated-recipe lint) before
+  calling any change done. `.github/workflows/lint.yml` runs the same recipe
+  on every push and PR, so a local pass is a CI pass.
+
+## Repository boundary
+
+There is no application source tree or conventional test directory in this
+repo; it only builds and configures OCI images. Do not commit private signing
+keys (`cosign.key`), registry tokens, or other generated secrets. Do not
+commit generated build artifacts (`bos_*`, `version.txt`, `changelog*.md`,
+`output*.env`) — these are build outputs, not source. Published images are
+signed with Cosign; keep `cosign.pub` public and store private signing
+material only in GitHub Actions secrets.
+
+## Documentation rules (enforced)
+
+Docs live in `docs/` in four categories. **Every new doc starts from its
+category's `TEMPLATE.md`** and follows its structure:
+
+- `docs/adr/` — why we decided. Immutable once Accepted; reversals are new
+  ADRs that mark the old one Superseded.
+- `docs/design/` — how it fits together. Living; updated in place to match
+  reality.
+- `docs/specs/` — exact contracts. Change only alongside implementing code.
+- `docs/plans/` — order of work. Phases with "Done when" outcomes.
+
+### Cross-linking is mandatory
+
+A doc without its required links is incomplete — do not finish a docs change
+until they exist, in both directions:
+
+- **ADR** → links every design doc/spec it shapes, and prior ADRs it builds on.
+- **Design doc** → links the ADR(s) providing its rationale, the spec(s)
+  pinning its contracts, and the roadmap phase that builds it.
+- **Spec** → links its motivating ADR(s) and the design doc showing where it
+  fits.
+- **Plan** → every phase links the design docs/specs it implements; resolved
+  open questions become ADRs.
+
+When you touch a doc, verify its links still hold (targets exist, section
+anchors valid) and add the back-links on the targets. Use relative paths.
+
+### Housekeeping
+
+- New doc ⇒ add a line to the index in [docs/README.md](docs/README.md).
+- New significant decision ⇒ new ADR *first*, then update the affected design
+  docs/specs in the same change.
+- Convert relative dates ("next weekend") to absolute dates in all docs.
+
+## Testing guidelines
+
+Run `just lint` before submitting changes. For build logic changes, also run
+at least one representative local build, for example `just build bazzite` for
+desktop changes or `just build ucore` for server changes. When changing
+`system_files/`, choose the image variant that consumes that overlay.
+
+## Commit & pull request guidelines
+
+Recent history uses Conventional Commit-style subjects such as `feat: add
+zellij` and `chore(deps): bump ...`. Keep commit titles concise and
+imperative. The repository enables semantic PR title checks, so PR titles
+should follow the same pattern. PRs should describe the affected image
+variants, list validation performed, and include relevant build or lint
+output when changing build, packaging, signing, or workflow behavior.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Justfile
+++ b/Justfile
@@ -713,7 +713,8 @@ merge-changelog:
 
 lint:
     # shell
-    /usr/bin/find . -iname "*.sh" -type f -exec shellcheck "{}" ';'
+    # Note: -exec ... + (not ';') so a shellcheck failure fails this recipe.
+    /usr/bin/find . -iname "*.sh" -type f -exec shellcheck "{}" +
     # yaml
     yamllint -s {{ justfile_dir() }}
     # just
@@ -730,10 +731,15 @@ format:
     just fix
 
 _lint-recipe linter recipe *args:
-    just -n {{ recipe }} {{ args }} 2>&1 | tee /tmp/{{ recipe }} >/dev/null && \
-    echo "Linting {{ recipe }} with {{ linter }}" && \
-    {{ linter }} /tmp/{{ recipe }} && rm /tmp/{{ recipe }} || \
-    rm /tmp/{{ recipe }}
+    #!/usr/bin/env bash
+    set ${SET_X:+-x} -eou pipefail
+    # The rendered recipe is linted from a temp file; the trap guarantees
+    # cleanup without swallowing the linter's exit status.
+    lintfile="$(mktemp -t lint-{{ recipe }}.XXXXXXXXXX)"
+    trap 'rm -f "${lintfile}"' EXIT
+    just -n {{ recipe }} {{ args }} > "${lintfile}" 2>&1
+    echo "Linting {{ recipe }} with {{ linter }}"
+    {{ linter }} "${lintfile}"
 
 lint-recipes:
     #!/usr/bin/bash

--- a/README.md
+++ b/README.md
@@ -58,13 +58,10 @@ cosign verify --key cosign.pub ghcr.io/bsherman/bos:TAG
 ## Build Scheduling
 
 Scheduled builds compare each variant's exact upstream image digest with the
-digest recorded on its signed published image. Only scheduled variants whose
-upstream image changed are rebuilt and published. Pull requests always build
-enabled variants for validation but do not publish; merges to `main` publish
-all enabled variants.
-
-Workflows run daily. The first scheduled run after adding digest metadata
-rebuilds every enabled variant because existing published images lack it.
+digest recorded on its signed published image, and skip variants that haven't
+changed. See [docs/design/build-scheduling.md](docs/design/build-scheduling.md)
+for the full mechanism and [ADR-0003](docs/adr/0003-digest-based-conditional-rebuild-scheduling.md)
+for why.
 
 ## DIY
 
@@ -89,3 +86,8 @@ The build system is intentionally straightforward:
 - `Justfile` — Local development commands (`just build`, `just lint`, `just format`, etc.).
   Image variants and build metadata are defined in `images.yaml`.
 - `Containerfile` — Minimal definition that copies everything and invokes `build.sh`
+
+See [docs/README.md](docs/README.md) for architecture decisions, design docs,
+specs, and plans. `AGENTS.md` holds the conventions coding agents follow in
+this repo (`CLAUDE.md`/`GEMINI.md`/`.github/copilot-instructions.md` are
+symlinks to it).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# Documentation
+
+Docs are split by the question they answer:
+
+| Directory | Question | Contents |
+| --- | --- | --- |
+| [adr/](adr/) | **Why** did we choose this? | Architecture Decision Records — immutable once accepted; superseded, never edited |
+| [design/](design/) | **How** does it fit together? | Living documents describing the current architecture |
+| [specs/](specs/) | **What exactly** is the contract? | Precise, testable interface definitions |
+| [plans/](plans/) | **When/in what order** do we build? | Roadmaps and phase plans; updated as work lands |
+
+## Index
+
+### Decisions (ADRs)
+
+- [0001 — Record architecture decisions](adr/0001-record-architecture-decisions.md)
+- [0002 — Agent-portable instruction surface](adr/0002-agent-portable-instruction-surface.md)
+- [0003 — Digest-based conditional rebuild scheduling](adr/0003-digest-based-conditional-rebuild-scheduling.md)
+
+### Design
+
+- [Build scheduling](design/build-scheduling.md)
+
+### Specs
+
+*(none yet)*
+
+### Plans
+
+*(none yet)*
+
+## Conventions
+
+- **New docs start from their category's `TEMPLATE.md`** (in each directory).
+- New decision → new ADR with the next number; if it reverses an old one, mark
+  the old one `Superseded by NNNN` rather than editing it.
+- Design docs are updated in place to always reflect reality.
+- Specs change only alongside the code that implements them.
+- Cross-links between categories are mandatory in both directions — see the
+  documentation rules in [AGENTS.md](../AGENTS.md) (CLAUDE.md/GEMINI.md are
+  symlinks to it, ADR-0002).
+- Adding a doc means adding it to the index above.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,35 @@
+# 0001 — Record architecture decisions
+
+- **Status:** Accepted
+- **Date:** 2026-08-06
+
+## Context
+
+This project will be built and maintained largely by LLM agents across many
+sessions. Decisions and their rationale must be discoverable by an agent (or
+a future maintainer) with no conversational context.
+
+## Decision
+
+Record every significant architecture decision as a numbered ADR in
+`docs/adr/`, using this format: Status, Date, Context, Decision, Consequences,
+Alternatives considered. ADRs are immutable once accepted; a reversal is a new
+ADR that marks the old one `Superseded by NNNN`.
+
+## Consequences
+
+- Agents can be pointed at `docs/adr/` to learn why things are the way they
+  are before proposing changes.
+- Slight writing overhead per decision; worth it for a project whose premise
+  is agent-maintainability.
+
+## Alternatives considered
+
+- **Decisions in commit messages or chat history:** not discoverable at the
+  moment of need; agents propose relitigating settled questions. Rejected.
+- **A single living DECISIONS.md:** edits erase the record of what was
+  believed when; immutability is the point. Rejected.
+
+## References
+
+- Shapes: [docs/README.md](../README.md), every future ADR

--- a/docs/adr/0002-agent-portable-instruction-surface.md
+++ b/docs/adr/0002-agent-portable-instruction-surface.md
@@ -1,0 +1,64 @@
+# 0002 — Agent-portable instruction surface
+
+- **Status:** Accepted
+- **Date:** 2026-08-06
+
+## Context
+
+The project is maintained by whichever coding agent is available — each tool
+reads its own instruction file (`CLAUDE.md`, `.github/copilot-instructions.md`,
+`GEMINI.md`, `AGENTS.md`) and its own skills location (`.claude/skills/`).
+Duplicating conventions per tool guarantees drift, and drift means different
+agents follow different law.
+
+## Decision
+
+One canonical surface, tool paths as symlinks:
+
+- **`AGENTS.md`** (the emerging cross-tool standard) is the real file holding
+  all conventions. `CLAUDE.md`, `GEMINI.md`, and
+  `.github/copilot-instructions.md` are symlinks to it.
+- **`.agents/skills/`** is the real skills directory (`<skill>/SKILL.md` with
+  YAML frontmatter). `.claude/skills` is a symlink to it.
+- Content is written tool-agnostically: plain markdown, no tool-specific
+  directives; anything only one tool understands stays out of the shared
+  files.
+
+## Consequences
+
+- Conventions and skills are edited in exactly one place; every agent sees
+  the same law.
+- Symlinks are committed to git — fine on Linux/macOS; GitHub's web renderer
+  may show link targets rather than content, an accepted cosmetic cost.
+  Native Windows checkouts need `core.symlinks=true` or WSL.
+- The skill format is the lowest common denominator (frontmatter + markdown
+  steps); agents without native skill support are pointed at the directory
+  from AGENTS.md.
+- The starter template is stored as `.agents/skills/TEMPLATE/SKILL.md.txt`,
+  not `SKILL.md` — a deliberate deviation from upstream agentic-template.
+  Skill discovery enumerates every `<dir>/SKILL.md` under `.claude/skills`,
+  so an upstream-named template would load in every session as a junk skill
+  (its placeholder frontmatter declares `name: skill-name`, which also
+  disagrees with its directory). Copy it to `<name>/SKILL.md` when writing a
+  real skill.
+- `AGENTS.md`/`CLAUDE.md` were previously gitignored in this repo (personal,
+  local-only agent config); this ADR reverses that — they are now committed
+  and canonical, and `.gitignore` no longer excludes them.
+  `.claude/settings.local.json` stays ignored (it is listed in the repo's own
+  `.gitignore`) since it holds machine-local tool permissions, not project
+  conventions.
+
+## Alternatives considered
+
+- **Per-tool copies kept in sync by convention:** guaranteed drift. Rejected.
+- **Instructions for one tool only:** wastes every other agent exactly when
+  it's needed. Rejected.
+- **Keep `AGENTS.md` gitignored/local-only:** this repo's prior convention;
+  keeps agent instructions out of the shared history, but means every
+  contributor (human or agent) starts from zero and conventions aren't
+  reviewable in PRs. Rejected in favor of the canonical, committed surface.
+
+## References
+
+- Builds on: [ADR-0001](0001-record-architecture-decisions.md)
+- Shapes: `AGENTS.md`, [.agents/skills/](../../.agents/skills/)

--- a/docs/adr/0003-digest-based-conditional-rebuild-scheduling.md
+++ b/docs/adr/0003-digest-based-conditional-rebuild-scheduling.md
@@ -1,0 +1,79 @@
+# 0003 — Digest-based conditional rebuild scheduling
+
+- **Status:** Accepted
+- **Date:** 2026-08-06
+
+## Context
+
+Desktop and server builds run on a daily schedule (`cron: "41 6 * * *"`) across
+every enabled image variant in `images.yaml`. Most upstream Bazzite/uCore base
+images do not change every day, so rebuilding, re-chunking, and re-signing
+every variant on every scheduled run burns CI minutes and produces image
+churn (new signed digests, changelog noise) for images whose content did not
+actually change upstream. Scheduled runs need a cheap, reliable way to decide
+*before* building whether a variant's upstream base has moved since the last
+published, signed build — without a separate state store, since CI runners
+are stateless between runs and the only durable record of "what did we last
+build" is the published image itself.
+
+## Decision
+
+`just generate-ci-matrix <flavor> <changed_only>` decides the build matrix:
+
+- For each CI-enabled variant, resolve the upstream base image's exact
+  manifest digest via `skopeo inspect --raw` (hashed, not the mutable tag).
+- When `changed_only=true` (scheduled runs only), compare that resolved
+  digest against the `org.opencontainers.image.base.digest` label already
+  recorded on the currently published, signed image for that tag, per
+  architecture. A variant is included in the matrix only if the label differs,
+  the published image/label is missing (new variant, or first run after this
+  mechanism shipped), or `cosign verify` on the currently published image
+  fails (fail toward rebuilding, not toward silently trusting an
+  unverifiable image).
+- Pull requests always set `changed_only=false` — every enabled variant
+  builds for validation — but never publish. Merges to `main` always publish
+  every enabled variant that built, regardless of digest state.
+- The digest resolved at matrix-generation time is threaded through as the
+  `base_digest` build argument (`just build <image> <base_digest>`), so the
+  image that gets built and labeled is pinned to the exact digest the matrix
+  decision was based on — not a possibly-newer tag resolved again at build
+  time. `build-image.yml`'s "Verify upstream base metadata" step asserts the
+  built image's label matches what the matrix selected.
+
+## Consequences
+
+- Scheduled runs skip variants with unchanged upstream bases, cutting daily
+  CI time/cost roughly in proportion to how many variants are actually
+  stable day to day.
+- The first scheduled run after this mechanism was introduced rebuilds every
+  enabled variant, since existing published images predate the
+  `base.digest` label.
+- A transient `skopeo` failure resolving the *upstream* digest fails the
+  matrix-generation job outright (retried 3x with backoff). Failures against
+  the *published* image split two ways: a `cosign verify` failure is treated
+  as "needs rebuild", but a `skopeo inspect` failure whose error doesn't look
+  like "image absent" aborts matrix generation for the whole flavor.
+- New variants added to `images.yaml` are built automatically on their first
+  scheduled run, since a missing published image/label is treated as
+  "changed."
+- Adds a runtime dependency on `skopeo` and `cosign` being available wherever
+  `generate-ci-matrix` runs (already required for local builds per
+  [AGENTS.md](../../AGENTS.md)).
+
+## Alternatives considered
+
+- **Rebuild every enabled variant on every scheduled run:** simplest, but was
+  the status quo problem — wasted CI time and produced unnecessary signed
+  image churn on unchanged variants. Rejected.
+- **Time-based staggered scheduling (e.g. rotate which variants build each
+  day):** doesn't track whether anything actually changed, so still rebuilds
+  unnecessarily on some days and can delay picking up a real upstream
+  security update on others. Rejected.
+- **External change-tracking (webhook/API from upstream ublue-os projects):**
+  no such notification mechanism is published by the upstream image
+  projects. Rejected as impractical.
+
+## References
+
+- Shapes: [docs/design/build-scheduling.md](../design/build-scheduling.md)
+- Builds on: none (first project-specific ADR)

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,37 @@
+# NNNN — Short imperative title
+
+<!--
+Filename: NNNN-kebab-case-title.md (next free number).
+ADRs are immutable once Accepted. To reverse one, write a new ADR and set the
+old one's Status to "Superseded by NNNN".
+-->
+
+- **Status:** Proposed | Accepted | Superseded by [NNNN](NNNN-title.md)
+- **Date:** YYYY-MM-DD
+
+## Context
+
+What situation forces a decision? Facts and constraints only — no solutions yet.
+
+## Decision
+
+The decision, stated in the active voice ("the server hosts a single gateway"),
+with just enough mechanism to be unambiguous.
+
+## Consequences
+
+What becomes easier, what becomes harder, what new obligations exist. Include
+the negative ones — they are the ones a future reader needs.
+
+## Alternatives considered
+
+- **Alternative:** why it was rejected (one or two sentences each).
+
+## References
+
+<!-- Required. Link every design doc, spec, or plan this decision shapes, and
+any prior ADRs it builds on. If nothing links here yet, link the design doc
+that will describe the implementation. -->
+
+- Shapes: [design/…](../design/…), [specs/…](../specs/…)
+- Builds on: [ADR-NNNN](NNNN-….md)

--- a/docs/design/TEMPLATE.md
+++ b/docs/design/TEMPLATE.md
@@ -1,0 +1,39 @@
+# Title (a system area, e.g. "LLM Gateway")
+
+<!--
+Design docs are LIVING documents: update them in place so they always describe
+the system as it is. Rationale does NOT live here — it lives in ADRs, linked
+below. If you find yourself writing "because", consider whether it belongs in
+an ADR.
+-->
+
+Living document. Rationale: [ADR-NNNN](../adr/NNNN-….md).
+Contracts: [specs/…](../specs/…).
+
+## Overview
+
+What this part of the system does, in a paragraph. A diagram if topology is
+involved:
+
+```
+component ──► component ──► component
+```
+
+## Design
+
+The current mechanism: components, responsibilities, data flow, interfaces
+(summarized — exact contracts belong in a spec).
+
+## Operational notes
+
+Bootstrap dependencies, health checks, failure modes, and anything a 3am
+debugging session would want to know.
+
+## References
+
+<!-- Required. Every design doc links: the ADRs that justify it, the specs
+that pin its contracts, and the roadmap phase that builds it. -->
+
+- Rationale: [ADR-NNNN](../adr/NNNN-….md)
+- Contracts: [specs/…](../specs/….md)
+- Built in: [roadmap — Phase N](../plans/roadmap.md)

--- a/docs/design/build-scheduling.md
+++ b/docs/design/build-scheduling.md
@@ -1,0 +1,92 @@
+# Build scheduling
+
+Living document. Rationale:
+[ADR-0003](../adr/0003-digest-based-conditional-rebuild-scheduling.md).
+
+## Overview
+
+Scheduled CI builds for bos's desktop and server image variants compare each
+variant's upstream base image digest against the digest recorded on the
+currently published, signed image before deciding what to build, so unchanged
+variants are skipped on daily scheduled runs.
+
+```
+schedule/push/PR ──► get-images (just generate-ci-matrix)
+                        │
+                        ▼
+                  build-image (matrix: image × arch)
+                        │
+                        ▼
+                  create-manifest (multi-arch manifest, sign, push)
+```
+
+## Design
+
+`.github/workflows/build-desktop.yml` and `build-server.yml` both call the
+reusable `build-image.yml` workflow with an `image_flavor` (`Bazzite` /
+`Server`), on a daily `schedule`, on `push`/`pull_request` to `main`, and on
+`workflow_dispatch`.
+
+**`get-images` job** runs `just generate-ci-matrix <flavor> <changed_only>`
+(`changed_only=true` only on `schedule` events):
+
+- `upstream_digest()` resolves each distinct `<base_image>:<base_tag>` pair's
+  exact manifest digest via `skopeo inspect --raw`, hashed with `sha256sum`,
+  and caches it per-key so variants sharing a base are only inspected once.
+- `variant_needs_rebuild()` checks, per architecture, whether the published
+  image's `org.opencontainers.image.base.digest` label matches the resolved
+  upstream digest. A missing/unpublished image (`manifest unknown`, `name
+  unknown`, `not found`, 404) is treated as needing a build — this is what
+  makes new variants build automatically on their first scheduled run. If the
+  label matches on every architecture, it falls back to `cosign verify` on
+  the published image; a verification failure is also treated as needing a
+  rebuild.
+- The matrix job emits `images` (flat list of `{image, arch, runner,
+  base_digest}`) and `manifest_images` (grouped by image, for the later
+  multi-arch manifest step), plus `publish` (`true` except on `pull_request`).
+
+**`build-image` job** runs `just build <image> <base_digest>` per matrix
+entry, pinning the build to the exact digest the matrix already resolved
+(not re-resolving the tag, which could have moved). It labels the built image
+with `org.opencontainers.image.base.digest=<base_digest>` and a "Verify
+upstream base metadata" step asserts the built image's label matches what was
+passed in, before pushing per-arch tags.
+
+**`create-manifest` job** (publish runs only) assembles the per-arch tags into
+a multi-arch manifest per image, pushes it under both the flavor tag and the
+resolved version tag, and signs both with Cosign.
+
+## Operational notes
+
+- The first scheduled run after this mechanism shipped rebuilds every enabled
+  variant, since existing published images predate the `base.digest` label.
+- `pull_request` runs always set `changed_only=false` (build everything,
+  validate, never publish) so PRs get full build coverage regardless of
+  upstream digest state.
+- Pushes to `main` always publish every enabled variant that built,
+  regardless of digest state — publishing is driven by the git event, not by
+  whether a rebuild was "needed."
+- To debug why a variant was or wasn't selected on a scheduled run, check the
+  "Get Images for Build" job's log output from `just generate-ci-matrix`
+  (`stderr` prints `Skipping <tag>; <base>:<tag> is unchanged` for skipped
+  variants).
+- `skopeo` transient failures resolving the *upstream* digest retry 3x with
+  backoff before failing the job (`cosign` is not involved in upstream digest
+  resolution — it only ever runs against published images).
+- A `cosign verify` failure on the *published* image is non-fatal and instead
+  forces a rebuild.
+- But a `skopeo inspect` failure on the *published* image is fatal to the
+  whole flavor: `variant_needs_rebuild()` only treats the error as "image
+  absent, build it" when stderr matches `manifest unknown|name unknown|not
+  found|no image found|status code: 404`. Anything else (registry 5xx, auth
+  blip, rate limit) returns `2` after 3 retries, and the caller does
+  `exit "${status}"` — so one bad published tag aborts matrix generation for
+  every variant in that flavor, not just its own. This is the failure mode to
+  suspect when a scheduled run dies in "Get Images for Build" with no matrix
+  emitted.
+
+## References
+
+- Rationale: [ADR-0003](../adr/0003-digest-based-conditional-rebuild-scheduling.md)
+- Built in: already shipped (PR #43 and follow-ups); not tracked in a
+  `docs/plans/` roadmap retroactively.

--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -1,0 +1,38 @@
+# Plan: Name (e.g. "Roadmap", "Migration to X")
+
+<!--
+Plans are updated as work lands: check off what shipped, renumber what moved.
+Every phase MUST have a "Done when" — a demonstrable outcome, not an activity.
+-->
+
+One paragraph: what this plan delivers and its relationship to other plans.
+
+## Phase 1 — Name (size estimate)
+
+- Work item, linking the [spec](../specs/….md) or [design doc](../design/….md)
+  it implements.
+- Work item.
+- **Done when:** a single observable outcome ("`hello.example.com` renders the
+  visitor's login name").
+
+## Phase 2 — Name
+
+- …
+- **Done when:** …
+
+## Later / ideas
+
+Unscheduled candidates. Move items up into a phase rather than letting this
+section become a second backlog.
+
+## Open questions
+
+- **Question:** what decides it, and by when (usually "by Phase N"). When one
+  is resolved, record the answer as an [ADR](../adr/TEMPLATE.md) if it changed
+  the architecture, then delete it here.
+
+## References
+
+<!-- Required. Link the design docs and specs this plan implements. -->
+
+- Implements: [design/…](../design/….md), [specs/…](../specs/….md)

--- a/docs/specs/TEMPLATE.md
+++ b/docs/specs/TEMPLATE.md
@@ -1,0 +1,47 @@
+# Spec: Thing Being Specified (e.g. a file format, CLI, endpoint)
+
+<!--
+Specs are precise, testable contracts. They change only alongside the code
+that implements them. Use MUST/SHOULD/MAY deliberately. If a requirement can't
+be checked mechanically or by a clear manual test, it belongs in a design doc
+instead.
+-->
+
+One paragraph: what this contract governs and who consumes it (code, agents,
+the CLI, other services).
+
+## Interface
+
+The exact shape — fields, commands, endpoints. Prefer tables for fields and
+fenced examples for formats:
+
+| Field | Type | Required | Constraints |
+| --- | --- | --- | --- |
+| `name` | string | yes | … |
+
+```toml
+# minimal valid example
+```
+
+## Rules
+
+Numbered or bulleted invariants, each independently checkable:
+
+- `slug` is immutable after creation.
+- Re-running any command converges to the same state (idempotence).
+
+## Derived artifacts
+
+<!-- If other things are generated from this contract, list them so a change
+here is understood to ripple. Delete the section if not applicable. -->
+
+| Artifact | Derivation |
+| --- | --- |
+
+## References
+
+<!-- Required. Every spec links: the ADR(s) that motivated it and the design
+doc that shows where it fits. -->
+
+- Rationale: [ADR-NNNN](../adr/NNNN-….md)
+- Context: [design/…](../design/….md)


### PR DESCRIPTION
## Summary
- Restructure around [bketelsen/agentic-template](https://github.com/bketelsen/agentic-template): `AGENTS.md` becomes the canonical, committed instruction file (`CLAUDE.md`/`GEMINI.md`/`.github/copilot-instructions.md` symlink to it, `.claude/skills` symlinks to `.agents/skills/`), and `docs/` splits by the question each doc answers (`adr/` why, `design/` how, `specs/` what exactly, `plans/` when).
- ADR-0003 + `docs/design/build-scheduling.md` formalize the existing digest-based conditional rebuild scheduling, replacing the informal explanation that previously lived only in README.
- Fixes a real bug found while reviewing this diff with `/code-review`: `just lint`'s shell and recipe-lint stages could never fail (`find -exec ... ';'` and `_lint-recipe`'s `|| rm` both swallowed shellcheck's exit code). Fixed the propagation and added `.github/workflows/lint.yml` so CI actually gates on it.

## Test plan
- [x] `just lint` passes on a clean tree
- [x] `just lint` verified to actually fail (exit 1, findings surfaced) when a shellcheck error is injected, then confirmed clean again
- [x] `just check` passes
- [x] All canonical symlinks resolve (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.claude/skills`)
- [x] All relative links in the new `docs/` files resolve; `docs/README.md` indexes every real doc
- [x] New `.gitignore` patterns (`changelog*.md`, `output*.env`, `previous.manifest.json`) verified to catch the intended artifacts and shadow nothing tracked