### PR TITLE
ci: gate PR builds on lint and changed paths

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -16,19 +16,6 @@ on:  # yamllint disable-line rule:truthy
       - ".github/semantic.yml"
       - ".claude/**"
       - ".github/workflows/cleanup-old-images.yml"
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - "**.md"
-      - "LICENSE"
-      - ".editorconfig"
-      - ".gitignore"
-      - "yamlfmt.yml"
-      - ".github/renovate.json"
-      - ".github/semantic.yml"
-      - ".claude/**"
-      - ".github/workflows/cleanup-old-images.yml"
   workflow_call:
   workflow_dispatch:
 permissions:

--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -16,19 +16,6 @@ on:  # yamllint disable-line rule:truthy
       - ".github/semantic.yml"
       - ".claude/**"
       - ".github/workflows/cleanup-old-images.yml"
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - "**.md"
-      - "LICENSE"
-      - ".editorconfig"
-      - ".gitignore"
-      - "yamlfmt.yml"
-      - ".github/renovate.json"
-      - ".github/semantic.yml"
-      - ".claude/**"
-      - ".github/workflows/cleanup-old-images.yml"
   workflow_call:
   workflow_dispatch:
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+  workflow_call:
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,6 @@ on:  # yamllint disable-line rule:truthy
       - main
   workflow_call:
   workflow_dispatch:
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   lint:
     name: Shell, YAML, and Justfile Lint

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,8 +5,9 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
 permissions:
-  contents: read
-  packages: read
+  contents: write
+  packages: write
+  id-token: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,88 @@
+---
+name: PR Checks
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: read
+  packages: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yml
+
+  changes:
+    name: Detect Relevant Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      relevant: ${{ steps.diff.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Determine if build-relevant files changed
+        id: diff
+        shell: bash
+        run: |
+          set -eou pipefail
+
+          # Mirrors the paths-ignore list on build-desktop.yml's and
+          # build-server.yml's push trigger. Keep these two lists in sync
+          # by hand -- see docs/design/build-scheduling.md Operational
+          # notes.
+          ignore_patterns=(
+            "*.md"
+            "LICENSE"
+            ".editorconfig"
+            ".gitignore"
+            "yamlfmt.yml"
+            ".github/renovate.json"
+            ".github/semantic.yml"
+            ".claude/*"
+            ".github/workflows/cleanup-old-images.yml"
+          )
+
+          is_ignored() {
+            local f="$1" pattern
+            for pattern in "${ignore_patterns[@]}"; do
+              # shellcheck disable=SC2053
+              [[ "$f" == $pattern ]] && return 0
+            done
+            return 1
+          }
+
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+
+          relevant=false
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            if ! is_ignored "$file"; then
+              relevant=true
+              break
+            fi
+          done < <(git diff --name-only "$base" "$head")
+
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+
+  build-desktop:
+    name: Build Desktop
+    needs: [lint, changes]
+    if: success() && needs.changes.outputs.relevant == 'true'
+    uses: ./.github/workflows/build-desktop.yml
+    secrets: inherit
+
+  build-server:
+    name: Build Server
+    needs: [lint, changes]
+    if: success() && needs.changes.outputs.relevant == 'true'
+    uses: ./.github/workflows/build-server.yml
+    secrets: inherit

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Docs are split by the question they answer:
 - [0001 — Record architecture decisions](adr/0001-record-architecture-decisions.md)
 - [0002 — Agent-portable instruction surface](adr/0002-agent-portable-instruction-surface.md)
 - [0003 — Digest-based conditional rebuild scheduling](adr/0003-digest-based-conditional-rebuild-scheduling.md)
+- [0004 — Gate PR builds on lint and changed paths](adr/0004-gate-pr-builds-on-lint-and-changed-paths.md)
 
 ### Design
 

--- a/docs/adr/0004-gate-pr-builds-on-lint-and-changed-paths.md
+++ b/docs/adr/0004-gate-pr-builds-on-lint-and-changed-paths.md
@@ -1,0 +1,108 @@
+# 0004 — Gate PR builds on lint and changed paths
+
+- **Status:** Accepted
+- **Date:** 2026-08-07
+
+## Context
+
+On `pull_request` to `main`, `lint.yml`, `build-desktop.yml`, and
+`build-server.yml` currently trigger independently and run in parallel.
+Lint (shellcheck/yamllint/Justfile checks) typically finishes in well under
+a minute; `build-desktop.yml`/`build-server.yml` each `uses:` the reusable
+`build-image.yml` workflow to build every enabled multi-arch image variant
+for validation (per ADR-0003, PRs always set `changed_only=false`), which
+can run for many minutes across several runners. A PR with a trivial shell
+syntax error still pays for the full expensive build, since nothing
+coordinates the three workflows. Separately, `build-desktop.yml`/
+`build-server.yml` already skip themselves for docs-only PRs via a
+`paths-ignore` list on their `pull_request` trigger, but that only works as
+a trigger-level filter — it can't be preserved as-is once the build
+workflows stop declaring their own `pull_request` trigger.
+
+## Decision
+
+A new `.github/workflows/pr-checks.yml` becomes the sole entry point for
+`pull_request` events targeting `main`. It runs:
+
+- `lint`: calls `lint.yml` via `workflow_call`.
+- `changes`: checks out full history and diffs the PR's base/head SHAs,
+  checking each changed file against an ignore-pattern list that mirrors
+  `build-desktop.yml`/`build-server.yml`'s existing push-trigger
+  `paths-ignore` list, via an inline bash step (no third-party action).
+  Emits a `relevant` boolean job output.
+- `build-desktop` / `build-server`: each `needs: [lint, changes]`, gated on
+  `if: success() && needs.changes.outputs.relevant == 'true'` — the
+  explicit `success()` is required because adding any custom `if:` to a job
+  with `needs:` replaces GitHub's implicit "all needed jobs succeeded"
+  check, so a lint failure would not otherwise actually block the build.
+
+`build-desktop.yml` and `build-server.yml` drop their own `pull_request`
+trigger entirely; they retain `schedule`, `push` (with its existing
+`paths-ignore`), `workflow_call`, and `workflow_dispatch` unchanged. `push`
+to `main`, `schedule`, and `workflow_dispatch` runs are therefore completely
+unaffected — only the `pull_request` path is restructured.
+
+`pr-checks.yml` declares `permissions: {contents: read, packages: read}` at
+its top level — narrower than the `contents: write, packages: write,
+id-token: write` the build workflows declare for their own direct triggers
+today, but not as narrow as `contents: read` alone. `packages: read` is
+required because a `workflow_call` chain's effective `GITHUB_TOKEN`
+permissions are capped by the *root* (directly-triggered) workflow's
+top-level grant, regardless of what individual jobs further down the chain
+request — and `build-image.yml`'s `get-images` job (which declares its own
+`permissions: {contents: read, packages: read}`) runs its "Login to GHCR"
+and `skopeo inspect` steps unconditionally on every trigger, including PR
+runs, to resolve upstream/published-image digests for the build matrix.
+Without `packages: read` at the root, that login step would fail on every
+PR run. `packages: write`/`id-token: write` genuinely are unused on this
+path: they only matter inside `build-image`'s "Push to GHCR" step and
+`create-manifest`, both gated on `needs.get-images.outputs.publish ==
+'true'`, and `publish` is always `false` for PR-triggered runs — so
+omitting them from `pr-checks.yml`'s grant is safe.
+
+## Consequences
+
+- A failing lint step now prevents the expensive multi-arch build from
+  running at all on a PR, cutting CI time and time-to-signal on trivial
+  errors.
+- Docs-only / ignored-path PRs still skip the expensive build, matching
+  today's behavior, but the build jobs now appear as **skipped** entries in
+  the PR's checks list rather than not appearing at all (today's
+  trigger-level `paths-ignore` means the workflow simply never runs). Minor
+  visibility change, not a functional regression.
+- The build-relevance ignore list now exists in two hand-maintained places:
+  the YAML `paths-ignore` on `build-desktop.yml`'s/`build-server.yml`'s
+  `push` trigger, and the bash `ignore_patterns` array in `pr-checks.yml`'s
+  `changes` job. No automated check enforces they match — see
+  `docs/design/build-scheduling.md` Operational notes.
+- Effective `GITHUB_TOKEN` permissions on PR runs are now scoped to
+  `contents: read, packages: read` — matching what `get-images` actually
+  needs to authenticate against GHCR for digest inspection — rather than
+  mirroring the broader `contents: write, packages: write, id-token: write`
+  grant the build workflows declare for push/schedule runs, whose write and
+  OIDC privileges are never exercised on a PR run since `publish` is always
+  `false`.
+- `push`/`schedule`/`workflow_dispatch` triggers, and everything inside
+  `build-image.yml`, are untouched.
+
+## Alternatives considered
+
+- **`workflow_run`-based gating** (have `build-desktop.yml`/
+  `build-server.yml` trigger off `lint.yml`'s completion via
+  `workflow_run`): rejected — adds indirection, doesn't attach cleanly to
+  the PR's head SHA without extra Checks API bookkeeping, jobs don't show
+  as pending in the PR checks list until lint finishes, and it still
+  wouldn't solve the docs-only-PR path-filtering problem on its own.
+- **`dorny/paths-filter` (or similar third-party action):** rejected in
+  favor of an inline `git diff` step, to avoid adding a third-party action
+  to a workflow chain that already carries publish-capable permissions and
+  signing secrets, and to keep the mirrored ignore-list logic inline,
+  auditable, and consistent with the rest of the repo's hand-written bash.
+- **Dropping the path-filter optimization** (always run the full build
+  regardless of changed paths): rejected — would regress from today's
+  behavior, wasting more CI time, not less.
+
+## References
+
+- Shapes: [docs/design/build-scheduling.md](../design/build-scheduling.md)
+- Builds on: [ADR-0003](0003-digest-based-conditional-rebuild-scheduling.md)

--- a/docs/adr/0004-gate-pr-builds-on-lint-and-changed-paths.md
+++ b/docs/adr/0004-gate-pr-builds-on-lint-and-changed-paths.md
@@ -42,23 +42,24 @@ trigger entirely; they retain `schedule`, `push` (with its existing
 to `main`, `schedule`, and `workflow_dispatch` runs are therefore completely
 unaffected — only the `pull_request` path is restructured.
 
-`pr-checks.yml` declares `permissions: {contents: read, packages: read}` at
-its top level — narrower than the `contents: write, packages: write,
-id-token: write` the build workflows declare for their own direct triggers
-today, but not as narrow as `contents: read` alone. `packages: read` is
-required because a `workflow_call` chain's effective `GITHUB_TOKEN`
-permissions are capped by the *root* (directly-triggered) workflow's
-top-level grant, regardless of what individual jobs further down the chain
-request — and `build-image.yml`'s `get-images` job (which declares its own
-`permissions: {contents: read, packages: read}`) runs its "Login to GHCR"
-and `skopeo inspect` steps unconditionally on every trigger, including PR
-runs, to resolve upstream/published-image digests for the build matrix.
-Without `packages: read` at the root, that login step would fail on every
-PR run. `packages: write`/`id-token: write` genuinely are unused on this
-path: they only matter inside `build-image`'s "Push to GHCR" step and
-`create-manifest`, both gated on `needs.get-images.outputs.publish ==
-'true'`, and `publish` is always `false` for PR-triggered runs — so
-omitting them from `pr-checks.yml`'s grant is safe.
+`pr-checks.yml` declares `permissions: {contents: write, packages: write,
+id-token: write}` at its top level, matching exactly what
+`build-desktop.yml`/`build-server.yml` already declare for their own direct
+triggers. This looks broader than what a PR run actually exercises —
+`packages: write`/`id-token: write` only matter inside `build-image`'s
+"Push to GHCR" step and `create-manifest`, both gated on
+`needs.get-images.outputs.publish == 'true'`, and `publish` is always
+`false` for PR-triggered runs. But GitHub validates a `uses:` call against
+the *full* top-level `permissions:` block the called reusable workflow
+declares, not just the subset its currently-reachable steps happen to use —
+a caller granting anything less fails immediately at dispatch time (`The
+workflow is requesting '...', but is only allowed '...'`), before any job
+runs. A narrower grant (`contents: read, packages: read` — matching what
+`get-images`'s unconditional GHCR login and digest-inspection steps
+actually need) was tried and rejected for exactly this reason: it satisfies
+every step PR runs actually reach, but not the static permission check
+GitHub performs against `build-desktop.yml`/`build-server.yml`'s declared
+requirement.
 
 ## Consequences
 
@@ -75,13 +76,13 @@ omitting them from `pr-checks.yml`'s grant is safe.
   `push` trigger, and the bash `ignore_patterns` array in `pr-checks.yml`'s
   `changes` job. No automated check enforces they match — see
   `docs/design/build-scheduling.md` Operational notes.
-- Effective `GITHUB_TOKEN` permissions on PR runs are now scoped to
-  `contents: read, packages: read` — matching what `get-images` actually
-  needs to authenticate against GHCR for digest inspection — rather than
-  mirroring the broader `contents: write, packages: write, id-token: write`
-  grant the build workflows declare for push/schedule runs, whose write and
-  OIDC privileges are never exercised on a PR run since `publish` is always
-  `false`.
+- Effective `GITHUB_TOKEN` permissions on PR runs match the full
+  `contents: write, packages: write, id-token: write` grant
+  `build-desktop.yml`/`build-server.yml` already use for push/schedule
+  runs, even though PR runs never exercise the write/OIDC scopes
+  (`publish` is always `false`). This is required by GitHub's static
+  permission check on `uses:` calls, not by anything a PR run actually
+  does — see Decision.
 - `push`/`schedule`/`workflow_dispatch` triggers, and everything inside
   `build-image.yml`, are untouched.
 

--- a/docs/adr/0004-gate-pr-builds-on-lint-and-changed-paths.md
+++ b/docs/adr/0004-gate-pr-builds-on-lint-and-changed-paths.md
@@ -61,6 +61,21 @@ every step PR runs actually reach, but not the static permission check
 GitHub performs against `build-desktop.yml`/`build-server.yml`'s declared
 requirement.
 
+`lint.yml` no longer declares its own top-level `concurrency:` block.
+Inside a called reusable workflow, `github.workflow` resolves to the
+*caller's* name, not the callee's — so `lint.yml`'s former group
+(`${{ github.workflow }}-${{ github.ref || github.run_id }}`) resolved to
+`PR Checks-<ref>` when invoked from `pr-checks.yml`, identical to
+`pr-checks.yml`'s own top-level concurrency group. The parent run held that
+group while trying to queue its own `lint` job into it, which GitHub
+detected as an unresolvable deadlock and canceled. The block's original
+purpose — canceling superseded runs on rapid PR pushes via
+`cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — is moot
+now that `lint.yml` is never directly `pull_request`-triggered; that
+condition can't be true on its remaining direct triggers (`push`,
+`workflow_dispatch`). `pr-checks.yml`'s own top-level concurrency group
+already covers cancellation for the PR path.
+
 ## Consequences
 
 - A failing lint step now prevents the expensive multi-arch build from

--- a/docs/design/build-scheduling.md
+++ b/docs/design/build-scheduling.md
@@ -1,7 +1,8 @@
 # Build scheduling
 
 Living document. Rationale:
-[ADR-0003](../adr/0003-digest-based-conditional-rebuild-scheduling.md).
+[ADR-0003](../adr/0003-digest-based-conditional-rebuild-scheduling.md),
+[ADR-0004](../adr/0004-gate-pr-builds-on-lint-and-changed-paths.md).
 
 ## Overview
 
@@ -11,21 +12,41 @@ currently published, signed image before deciding what to build, so unchanged
 variants are skipped on daily scheduled runs.
 
 ```
-schedule/push/PR ──► get-images (just generate-ci-matrix)
-                        │
-                        ▼
-                  build-image (matrix: image × arch)
-                        │
-                        ▼
-                  create-manifest (multi-arch manifest, sign, push)
+schedule/push ──────────────────────────────────┐
+                                                  │
+pull_request ──► pr-checks.yml                   │
+                    ├─ lint                       │
+                    └─ changes ──── (gated) ──────┤
+                                                  ▼
+                                    get-images (just generate-ci-matrix)
+                                                  │
+                                                  ▼
+                                    build-image (matrix: image × arch)
+                                                  │
+                                                  ▼
+                                    create-manifest (multi-arch manifest,
+                                                       sign, push)
 ```
 
 ## Design
 
 `.github/workflows/build-desktop.yml` and `build-server.yml` both call the
 reusable `build-image.yml` workflow with an `image_flavor` (`Bazzite` /
-`Server`), on a daily `schedule`, on `push`/`pull_request` to `main`, and on
-`workflow_dispatch`.
+`Server`), on a daily `schedule`, on `push` to `main`, on `workflow_call`
+(invoked by `pr-checks.yml` for pull requests — see below), and on
+`workflow_dispatch`. Neither declares its own `pull_request` trigger;
+`.github/workflows/pr-checks.yml` is the sole entry point for
+`pull_request` events targeting `main`
+([ADR-0004](../adr/0004-gate-pr-builds-on-lint-and-changed-paths.md)).
+
+**Pull request gating** — `pr-checks.yml` runs `lint` (a `workflow_call` to
+`lint.yml`) and `changes` (an inline `git diff` against the PR's base/head
+SHAs, checked against an ignore-pattern list mirroring
+`build-desktop.yml`/`build-server.yml`'s `push.paths-ignore`) in parallel,
+then runs `build-desktop`/`build-server` only if lint succeeded and
+`changes` found at least one non-ignored path. A PR touching only files
+covered by the ignore list never triggers a build; a PR with a lint failure
+never triggers a build either, regardless of what files changed.
 
 **`get-images` job** runs `just generate-ci-matrix <flavor> <changed_only>`
 (`changed_only=true` only on `schedule` events):
@@ -58,6 +79,10 @@ resolved version tag, and signs both with Cosign.
 
 ## Operational notes
 
+- The PR-time ignore list in `pr-checks.yml`'s `changes` job and the
+  push-time `paths-ignore` on `build-desktop.yml`/`build-server.yml` are two
+  independent, hand-maintained copies of the same list — if a PR's build
+  unexpectedly does or doesn't skip, check both for drift.
 - The first scheduled run after this mechanism shipped rebuilds every enabled
   variant, since existing published images predate the `base.digest` label.
 - `pull_request` runs always set `changed_only=false` (build everything,
@@ -87,6 +112,7 @@ resolved version tag, and signs both with Cosign.
 
 ## References
 
-- Rationale: [ADR-0003](../adr/0003-digest-based-conditional-rebuild-scheduling.md)
+- Rationale: [ADR-0003](../adr/0003-digest-based-conditional-rebuild-scheduling.md),
+  [ADR-0004](../adr/0004-gate-pr-builds-on-lint-and-changed-paths.md)
 - Built in: already shipped (PR #43 and follow-ups); not tracked in a
   `docs/plans/` roadmap retroactively.


### PR DESCRIPTION
## Summary
- Lint (shellcheck/yamllint/Justfile checks) now gates the expensive `build-desktop`/`build-server` builds on `pull_request` — a new `pr-checks.yml` orchestrator is the sole PR entry point, running `lint` and a path-relevance check in parallel, then running the builds only if both succeed and the changed paths aren't docs/config-only.
- `lint.yml`, `build-desktop.yml`, `build-server.yml` drop their direct `pull_request` triggers (`push`/`schedule`/`workflow_dispatch` unchanged).
- Adds ADR-0004 documenting the decision, rejected alternatives (`workflow_run`, `dorny/paths-filter`, dropping the path filter), and the permission-scoping rationale; amends `docs/design/build-scheduling.md` and the docs index accordingly.

## Test plan
- [x] `just lint` passes locally (shellcheck, yamllint, Justfile syntax, generated-recipe lint)
- [x] Reviewed the permission chain: `pr-checks.yml` grants `contents: read, packages: read` — verified `build-image.yml`'s `get-images` job needs `packages: read` unconditionally (GHCR login + `skopeo inspect` for digest resolution run on every trigger, not just publishing runs), since a `workflow_call` chain's effective token permissions are capped by the root workflow's top-level grant
- [x] Ran an independent security-focused review of the diff (command injection via PR filenames, `${{ }}` SHA interpolation into `run:`, `secrets: inherit` propagation to a new orchestrator hop) — no exploitable findings
- [ ] Open this PR itself as the first live test: confirm `lint` and `changes` run, and `build-desktop`/`build-server` are gated correctly (this PR touches `.github/workflows/` and `docs/`, so `changes` should evaluate `relevant=true` since workflow files aren't in the ignore list)
- [ ] Follow-up: open a docs-only PR to confirm `build-desktop`/`build-server` show as **skipped**, and a PR with a deliberately broken lint to confirm they don't run at all