### PR TITLE
fix(bazzite): restore kde-partitionmanager, drop lutris on desktop

### DIFF
--- a/build_scripts/desktop-changes.sh
+++ b/build_scripts/desktop-changes.sh
@@ -22,5 +22,24 @@ if [[ ${IMAGE} =~ bluefin|bazzite ]]; then
     # NOTE: these no longer seem to be installed on bazzite
     $DNF -y remove input-leap solaar virt-manager virt-viewer virt-v2v
 
+    if [[ ${IMAGE} =~ bazzite ]]; then
+        # Bazzite KDE variants swap kde-partitionmanager for gnome-disk-utility
+        # upstream; restore kde-partitionmanager for the KDE experience.
+        if [[ ! ${IMAGE} =~ gnome ]]; then
+            echo "Restoring kde-partitionmanager..."
+            $DNF -y remove gnome-disk-utility
+            $DNF -y install kde-partitionmanager
+        fi
+
+        if [[ ${IMAGE} =~ gnome ]]; then
+            # gnome-desktop3 is used by the GNOME desktop itself here, not just lutris
+            echo "Removing lutris..."
+            $DNF -y remove lutris
+        else
+            echo "Removing lutris and its gnome-desktop3 dependency..."
+            $DNF -y remove lutris gnome-desktop3
+        fi
+    fi
+
     /ctx/build_scripts/common-hygiene.sh
 fi


### PR DESCRIPTION
## Summary
- Restore `kde-partitionmanager` (removing `gnome-disk-utility`) on Bazzite KDE variants — upstream swaps this even on the KDE image.
- Remove `lutris` from all Bazzite variants; also removes its `gnome-desktop3` dependency on non-GNOME variants (GNOME variants keep `gnome-desktop3` since the GNOME desktop itself needs it).

## Test plan
- [x] `just lint`
- [x] `just build bazzite` — verified via `rpm -q`: `kde-partitionmanager` installed, `gnome-disk-utility`/`lutris`/`gnome-desktop3` removed
- [x] `just build bazzite-gnome` — verified via `rpm -q`: `lutris` removed, `gnome-desktop3` retained, `gnome-disk-utility` untouched