### PR TITLE
fix(bazzite): pin kde-partitionmanager to installed kpmcore version

### DIFF
--- a/build_scripts/desktop-changes.sh
+++ b/build_scripts/desktop-changes.sh
@@ -28,7 +28,20 @@ if [[ ${IMAGE} =~ bluefin|bazzite ]]; then
         if [[ ! ${IMAGE} =~ gnome ]]; then
             echo "Restoring kde-partitionmanager..."
             $DNF -y remove gnome-disk-utility
-            $DNF -y install kde-partitionmanager
+            # kde-partitionmanager and kpmcore are released in lockstep
+            # upstream (matching KDE Gear version numbers), but
+            # kde-partitionmanager's RPM only requires the libkpmcore soname,
+            # not a version -- so dnf can pair a newer kde-partitionmanager
+            # with the older kpmcore already in the base image, producing an
+            # ABI mismatch (undefined symbol at runtime). Pin
+            # kde-partitionmanager to whatever kpmcore version is already
+            # installed to keep them matched.
+            kpmcore_ver=$(rpm -q --qf '%{version}-%{release}' kpmcore 2>/dev/null || true)
+            if [[ -n ${kpmcore_ver} ]]; then
+                $DNF -y install "kde-partitionmanager-${kpmcore_ver}"
+            else
+                $DNF -y install kde-partitionmanager
+            fi
         fi
 
         if [[ ${IMAGE} =~ gnome ]]; then


### PR DESCRIPTION
## Summary
- `kde-partitionmanager`'s RPM only declares a dependency on the `libkpmcore` soname, not a version, so a plain `dnf install kde-partitionmanager` (added in #51) can pick a newer `kde-partitionmanager` while leaving the older `kpmcore` already baked into the base image untouched.
- Upstream releases the two in lockstep (matching KDE Gear version numbers) but occasionally breaks ABI without bumping the soname — this bit us today: `kde-partitionmanager-26.08.0` + `kpmcore-26.04.3` produced `undefined symbol: _ZTV22TakeOwnershipOperation` at runtime on `bos:bazzite`.
- Pin the `kde-partitionmanager` install to whatever `kpmcore` version is already present in the image, so they can't drift apart. Falls back to an unpinned install if `kpmcore` isn't present yet.

## Test plan
- [x] `just lint` passes
- [x] `bash -n build_scripts/desktop-changes.sh` syntax check
- [ ] `just build bazzite` local image build + verify `partitionmanager` launches without the symbol error (not yet run locally; CI build on this PR will also validate)