### PR TITLE
feat(desktop): ship Klassy and Qogir on KDE images

### DIFF
--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -12,6 +12,7 @@ repos=(
     fedora-updates-testing.repo
     gh-cli.repo
     google-chrome.repo
+    home_paulmcauley.repo
     negativo17-fedora-multimedia.repo
     negativo17-fedora-nvidia.repo
     nvidia-container-toolkit.repo

--- a/build_scripts/desktop-kde-themes.sh
+++ b/build_scripts/desktop-kde-themes.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set ${SET_X:+-x} -eou pipefail
+
+# Klassy is a Plasma plugin; Qogir is an icon theme. Skip GNOME/Bluefin.
+if [[ ! ${IMAGE} =~ bazzite ]] || [[ ${IMAGE} =~ gnome ]]; then
+    echo "Skipping KDE themes on ${IMAGE}"
+    exit 0
+fi
+
+echo "Installing Klassy..."
+
+fedora_version="$(rpm -E %fedora)"
+obs_base="https://download.opensuse.org/repositories/home:/paulmcauley"
+repo_url="${obs_base}/Fedora_${fedora_version}/home:paulmcauley.repo"
+repo_file="/etc/yum.repos.d/home_paulmcauley.repo"
+
+if ! curl --fail --retry 5 --retry-delay 5 --retry-all-errors \
+    -sL -o "${repo_file}" "${repo_url}"; then
+    echo "ERROR: Klassy OBS repo missing for Fedora ${fedora_version}" >&2
+    echo "${repo_url}" >&2
+    exit 1
+fi
+
+# Fail closed if OBS served a page instead of a repo file.
+grep -q '^\[home_paulmcauley\]' "${repo_file}"
+grep -q '^gpgcheck=1' "${repo_file}"
+
+$DNF install -y klassy
+sed -i 's@enabled=1@enabled=0@g' "${repo_file}"
+rpm -q klassy
+
+echo "Installing Qogir icon theme..."
+
+# Pin: vinceliuice/Qogir-icon-theme master @ 2025-11-04.
+# -c dark maps to Light in upstream install.sh; -c all is required.
+qogir_sha="c633057ba0d27a504b3255144071c9691ed0264a"
+qogir_sha256="4e13a959ddae29c95eac6d339217565df88e5a1ff3dfdfc1c1dc9bce83a3719a"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+tarball="${workdir}/qogir.tar.gz"
+
+/ctx/build_scripts/github-release-url.sh \
+    vinceliuice/Qogir-icon-theme \
+    --snapshot "${qogir_sha}" \
+    -o "${tarball}" \
+    --sha256 "${qogir_sha256}"
+
+tar -xzf "${tarball}" -C "${workdir}"
+mapfile -t qogir_dirs < <(
+    find "${workdir}" -mindepth 1 -maxdepth 1 -type d
+)
+if ((${#qogir_dirs[@]} != 1)); then
+    echo "ERROR: expected one Qogir source dir, found ${#qogir_dirs[@]}" >&2
+    exit 1
+fi
+src="${qogir_dirs[0]}"
+mkdir -p /usr/share/icons
+"${src}/install.sh" -d /usr/share/icons -t default -c all
+
+[[ -f /usr/share/icons/Qogir/index.theme ]]
+[[ -f /usr/share/icons/Qogir-Dark/index.theme ]]
+[[ -f /usr/share/icons/Qogir-Light/index.theme ]]

--- a/build_scripts/desktop-packages.sh
+++ b/build_scripts/desktop-packages.sh
@@ -4,6 +4,7 @@ set ${SET_X:+-x} -eou pipefail
 
 echo "Running desktop packages scripts..."
 /ctx/build_scripts/desktop-sunshine.sh
+/ctx/build_scripts/desktop-kde-themes.sh
 #echo "Running desktop packages scripts..."
 #/ctx/build_scripts/desktop-1password.sh
 

--- a/build_scripts/github-release-url.sh
+++ b/build_scripts/github-release-url.sh
@@ -1,65 +1,160 @@
 #!/bin/bash
 #
-# A script to print the URL of an asset from latest github release.
+# Fetch a file from GitHub: a release asset, or a repo snapshot tarball.
 #
-# ORG_PROJ is the pair of URL components for organization/projectName in Github URL
+# ORG_PROJ is the organization/projectName pair from a GitHub URL.
 # example: https://github.com/wez/wezterm/releases
 #   ORG_PROJ would be "wez/wezterm"
 #
-# ARCH_FILTER is used to select the specific RPM. Typically this can just be the arch
-#   such as 'x86_64' but sometimes a specific filter is required when multiple match.
-# example: wezterm builds RPMs for different distros so we must be more specific.
-#   ARCH_FILTER of "fedora37.x86_64" gets the x86_64 RPM build for fedora37
+# Release asset:
+#   ARCH_FILTER selects the asset by filename regex. Typically the arch
+#   such as 'x86_64', or a tighter filter when multiple assets match.
+#   example: wezterm builds per-distro RPMs, so "fedora37.x86_64".
+#   TAG is an optional release tag (default: latest).
+#   With --output, the asset is downloaded; otherwise its URL is printed.
+#
+# Snapshot:
+#   --snapshot REF downloads github.com/ORG_PROJ/archive/REF.tar.gz
+#   REF may be a commit SHA, tag, or branch. --output is required.
 
-ORG_PROJ=${1}
-ARCH_FILTER=${2}
-LATEST=${3}
+ORG_PROJ="${1:-}"
 
 usage() {
-    echo "$0 ORG_PROJ ARCH_FILTER"
-    echo "    ORG_PROJ    - organization/projectname"
-    echo "    ARCH_FILTER - optional extra filter to further limit rpm selection"
-    echo "    LATEST      - optional tag override for latest release (eg, nightly-dev)"
-
+    echo "$0 ORG_PROJ ARCH_FILTER [TAG] [-o DEST] [--sha256 HASH]"
+    echo "$0 ORG_PROJ --snapshot REF -o DEST [--sha256 HASH]"
+    echo "    ORG_PROJ     - organization/projectname"
+    echo "    ARCH_FILTER  - extra filter to limit release asset selection"
+    echo "    TAG          - optional release tag (default: latest)"
+    echo "    --snapshot   - git ref (commit SHA, tag, or branch)"
+    echo "    -o, --output - download destination path"
+    echo "    --sha256     - optional hash to verify a download"
 }
 
-if [ -z "${ORG_PROJ}" ]; then
+if [[ -z ${ORG_PROJ} || ${ORG_PROJ} == -* ]]; then
     usage
     exit 1
 fi
+shift
 
-if [ -z "${ARCH_FILTER}" ]; then
+snapshot_ref=""
+dest=""
+sha256=""
+positionals=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --snapshot)
+        snapshot_ref="${2:-}"
+        if [[ -z ${snapshot_ref} ]]; then
+            echo "ERROR: --snapshot requires a git ref" >&2
+            exit 1
+        fi
+        shift 2
+        ;;
+    --sha256)
+        sha256="${2:-}"
+        if [[ -z ${sha256} ]]; then
+            echo "ERROR: --sha256 requires a hash" >&2
+            exit 1
+        fi
+        shift 2
+        ;;
+    -o | --output)
+        dest="${2:-}"
+        if [[ -z ${dest} ]]; then
+            echo "ERROR: --output requires a path" >&2
+            exit 1
+        fi
+        shift 2
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    -*)
+        echo "Unknown option: $1" >&2
+        usage
+        exit 1
+        ;;
+    *)
+        positionals+=("$1")
+        shift
+        ;;
+    esac
+done
+
+set ${SET_X:+-x} -eou pipefail
+
+github_curl() {
+    local -a auth=()
+    if [[ -r /run/secrets/GITHUB_TOKEN ]]; then
+        local token
+        token=$(</run/secrets/GITHUB_TOKEN)
+        auth=(-H "Authorization: Bearer ${token}")
+    fi
+    curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sL \
+        "${auth[@]}" "$@"
+}
+
+download() {
+    local url="$1"
+    mkdir -p "$(dirname "${dest}")"
+    github_curl -o "${dest}" "${url}"
+    if [[ -n ${sha256} ]]; then
+        echo "${sha256}  ${dest}" | sha256sum -c -
+    fi
+}
+
+if [[ -n ${snapshot_ref} ]]; then
+    if ((${#positionals[@]} > 0)); then
+        echo "ERROR: --snapshot does not take ARCH_FILTER/TAG" >&2
+        usage
+        exit 1
+    fi
+    if [[ -z ${dest} ]]; then
+        echo "ERROR: --snapshot requires --output DEST" >&2
+        usage
+        exit 1
+    fi
+    download \
+        "https://github.com/${ORG_PROJ}/archive/${snapshot_ref}.tar.gz"
+    exit 0
+fi
+
+arch_filter="${positionals[0]:-}"
+tag="${positionals[1]:-}"
+
+if [[ -z ${arch_filter} ]]; then
     usage
     exit 2
 fi
 
-if [ -z "${LATEST}" ]; then
-    RELTAG="latest"
+if [[ -z ${tag} ]]; then
+    reltag="latest"
 else
-    RELTAG="tags/${LATEST}"
+    reltag="tags/${tag}"
 fi
 
-set ${SET_X:+-x} -eou pipefail
+api_json=$(mktemp /tmp/api-XXXXXXXX.json)
+trap 'rm -f "${api_json}"' EXIT
+api="https://api.github.com/repos/${ORG_PROJ}/releases/${reltag}"
 
-API_JSON=$(mktemp /tmp/api-XXXXXXXX.json)
-API="https://api.github.com/repos/${ORG_PROJ}/releases/${RELTAG}"
-
-# Read GitHub token from secret mount if available (authenticates API to avoid rate limits)
-CURL_AUTH_ARGS=()
-if [[ -r /run/secrets/GITHUB_TOKEN ]]; then
-    GITHUB_TOKEN=$(</run/secrets/GITHUB_TOKEN)
-    CURL_AUTH_ARGS=("-H" "Authorization: Bearer ${GITHUB_TOKEN}")
-fi
-# retry up to 5 times with 5 second delays for any error included HTTP 404 etc
-curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sL \
-    "${CURL_AUTH_ARGS[@]}" "${API}" -o "${API_JSON}"
-TGZ_URLS=$(jq \
+github_curl -o "${api_json}" "${api}"
+mapfile -t asset_urls < <(jq \
     -r \
-    --arg arch_filter "${ARCH_FILTER}" \
+    --arg arch_filter "${arch_filter}" \
     '.assets | sort_by(.created_at) | reverse | .[] | select(.name|test($arch_filter)) | select (.name) | .browser_download_url' \
-    "${API_JSON}")
-for URL in ${TGZ_URLS}; do
-    # WARNING: in case of multiple matches, this only prints the first matched asset
-    echo "${URL}"
-    break
-done
+    "${api_json}")
+
+if ((${#asset_urls[@]} == 0)); then
+    echo "No asset matched '${arch_filter}' in ${ORG_PROJ} ${reltag}" >&2
+    exit 3
+fi
+
+url="${asset_urls[0]}"
+if [[ -n ${dest} ]]; then
+    download "${url}"
+else
+    # WARNING: if multiple assets match, only the first URL is printed
+    echo "${url}"
+fi


### PR DESCRIPTION
## Summary

- Install Klassy (OBS `home:paulmcauley`) and a pinned Qogir icon theme on Bazzite KDE tags (`bazzite`, `bazzite-nvidia`, plus testing/deck; not GNOME).
- Leave Bazzite's default look-and-feel unchanged; both themes are selectable in System Settings.
- Disable the OBS repo after install and in `cleanup.sh`.
- Extend `github-release-url.sh` to download GitHub repo snapshots (commit/tag/branch) with optional sha256 verification, and use it for Qogir.

## Testing

- `just lint`
- `just build bazzite` — Klassy `6.7.2-1.5` from OBS; Qogir / Qogir-Light / Qogir-Dark under `/usr/share/icons`
- Local `github-release-url.sh --snapshot` download + sha256 mismatch + missing `--output` checks